### PR TITLE
Fix: Auto-select category in add form when clicking sidebar category

### DIFF
--- a/index.html
+++ b/index.html
@@ -879,6 +879,13 @@
                     option.textContent = category.name
                     this.categorySelect.appendChild(option)
                 })
+
+                // Maintain sync with selected category after rebuilding dropdown
+                if (this.selectedCategoryId === null || this.selectedCategoryId === 'uncategorized') {
+                    this.categorySelect.value = ''
+                } else {
+                    this.categorySelect.value = this.selectedCategoryId
+                }
             }
 
             selectCategory(categoryId) {


### PR DESCRIPTION
## Summary

Improves UX by automatically selecting a category in the "Add Todo" form when users click on a category in the left sidebar.

## Changes

- Modified `selectCategory()` method in `index.html:884` to update the category dropdown (`categorySelect`) based on the selected category
- When "All Todos" is clicked → dropdown clears (no category selected)
- When "Uncategorized" is clicked → dropdown clears (no category selected)
- When a specific category is clicked → dropdown selects that category

## Benefits

- Faster workflow: users can immediately add todos to the category they're viewing
- More intuitive: the form state matches the current view/filter
- Reduces clicks: no need to manually select the category in the dropdown

## Test Plan

- [ ] Click "All Todos" → verify dropdown shows "No Category"
- [ ] Click "Uncategorized" → verify dropdown shows "No Category"
- [ ] Click a specific category → verify dropdown shows that category
- [ ] Add a new todo while viewing a category → verify it gets the correct category
- [ ] Switch between categories → verify dropdown updates each time

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)