### PR TITLE
Fix: Use POSIX-compatible sed regex

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Update version in index.html
         run: |
-          sed -i "s/const APP_VERSION = '[0-9]\+\.[0-9]\+\.[0-9]\+'/const APP_VERSION = '${{ steps.new_version.outputs.version }}'/" index.html
+          sed -i "s/const APP_VERSION = '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*'/const APP_VERSION = '${{ steps.new_version.outputs.version }}'/" index.html
           if ! grep -q "const APP_VERSION = '${{ steps.new_version.outputs.version }}'" index.html; then
             echo "Error: Failed to update version in index.html"
             exit 1
@@ -56,7 +56,7 @@ jobs:
       - name: Update VERSION.md
         run: |
           TODAY=$(date +%Y-%m-%d)
-          sed -i "s/^**Current Version:** [0-9]\+\.[0-9]\+\.[0-9]\+/**Current Version:** ${{ steps.new_version.outputs.version }}/" VERSION.md
+          sed -i "s/^**Current Version:** [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/**Current Version:** ${{ steps.new_version.outputs.version }}/" VERSION.md
           if ! grep -q "^**Current Version:** ${{ steps.new_version.outputs.version }}" VERSION.md; then
             echo "Error: Failed to update version in VERSION.md"
             exit 1


### PR DESCRIPTION
## Problem

Workflow failing at **Update VERSION.md** step with sed error:
```
sed: -e expression #1, char 77: Invalid preceding regular expression
```

**Failed Run:** https://github.com/RadekCap/todolist/actions/runs/19748829010

## Root Cause

The sed regex uses **`\+` quantifier** which is **not supported in basic sed** on Ubuntu GitHub runners. The `\+` syntax is a GNU extension that requires the `-E` flag for extended regex mode.

**Failing Command:**
```bash
sed -i "s/^**Current Version:** [0-9]\+\.[0-9]\+\.[0-9]\+/**Current Version:** 1.0.6/" VERSION.md
```

## Solution

Replace `\+` with **POSIX-compatible pattern** `[0-9][0-9]*`:

### Pattern Comparison
- **Before:** `[0-9]\+` (GNU extension, requires -E)
- **After:** `[0-9][0-9]*` (POSIX basic regex)

Both patterns match "one or more digits" but the second works in basic sed without flags.

### Files Changed
- Line 49: Update version in index.html
- Line 59: Update VERSION.md

## Expected Result

After merging, the workflow should:
1. ✅ Parse YAML successfully
2. ✅ Checkout repository
3. ✅ Get current version (1.0.5)
4. ✅ Increment to 1.0.6
5. ✅ Update index.html successfully
6. ✅ Update VERSION.md successfully (no sed error)
7. ✅ Commit and push changes
8. ✅ Complete workflow run

This will finally enable automatic version bumping!

Fixes https://github.com/RadekCap/todolist/actions/runs/19748829010