### PR TITLE
Fix: Escape asterisks in sed regex patterns

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -56,12 +56,12 @@ jobs:
       - name: Update VERSION.md
         run: |
           TODAY=$(date +%Y-%m-%d)
-          sed -i "s/^**Current Version:** [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/**Current Version:** ${{ steps.new_version.outputs.version }}/" VERSION.md
+          sed -i "s/^\*\*Current Version:\*\* [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/**Current Version:** ${{ steps.new_version.outputs.version }}/" VERSION.md
           if ! grep -q "^**Current Version:** ${{ steps.new_version.outputs.version }}" VERSION.md; then
             echo "Error: Failed to update version in VERSION.md"
             exit 1
           fi
-          sed -i "s/^**Last Updated:** .*/**Last Updated:** $TODAY/" VERSION.md
+          sed -i "s/^\*\*Last Updated:\*\* .*/**Last Updated:** $TODAY/" VERSION.md
           echo "Updated VERSION.md"
 
       - name: Commit and push version bump


### PR DESCRIPTION
## Problem

Workflow still failing at Update VERSION.md step:
```
sed: -e expression #1, char 89: Invalid preceding regular expression
```

**Failed Run:** https://github.com/RadekCap/todolist/actions/runs/19748852174

## Root Cause

The `**` characters in the sed pattern need to be escaped. In regex, `*` is a special character (zero or more quantifier), so `**` is invalid.

**Failing Pattern:**
```bash
sed -i "s/^**Current Version:** [0-9].../**Current Version:** 1.0.6/"
           ^^                        ^^
           Not escaped!
```

## Solution

Escape asterisks with backslash:

### Before
```bash
s/^**Current Version:** .../
s/^**Last Updated:** .../
```

### After
```bash
s/^\*\*Current Version:\*\* .../
s/^\*\*Last Updated:\*\* .../
```

Now `**` is treated as two literal asterisk characters, not regex operators.

## Impact

This should finally allow the workflow to:
1. ✅ Update VERSION.md successfully
2. ✅ Commit the version bump
3. ✅ Increment version from 1.0.5 to 1.0.6

Fixes https://github.com/RadekCap/todolist/actions/runs/19748852174