### PR TITLE
Fix: Improve mobile display and responsiveness (fixes #44)

### DIFF
--- a/index.html
+++ b/index.html
@@ -855,6 +855,98 @@
             #categorySelect {
                 min-width: auto;
             }
+
+            .user-header {
+                flex-direction: column;
+                gap: 10px;
+                align-items: stretch;
+            }
+
+            .user-info {
+                flex-direction: column;
+                align-items: center;
+                text-align: center;
+            }
+
+            .user-actions {
+                justify-content: center;
+            }
+
+            .todo-item {
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+
+            .todo-text {
+                width: calc(100% - 32px);
+                order: 1;
+            }
+
+            .todo-checkbox {
+                order: 0;
+            }
+
+            .todo-category-badge,
+            .todo-priority-badge,
+            .todo-date {
+                order: 2;
+                font-size: 11px;
+                padding: 3px 8px;
+            }
+
+            .delete-btn {
+                order: 3;
+                width: 100%;
+                margin-top: 5px;
+            }
+
+            .modal {
+                width: 95%;
+                padding: 20px;
+                margin: 10px;
+            }
+
+            .modal-actions {
+                flex-direction: column;
+            }
+
+            .modal-btn {
+                width: 100%;
+            }
+
+            .stats {
+                flex-direction: column;
+                gap: 5px;
+                text-align: center;
+            }
+
+            .add-todo-btn {
+                padding: 12px 20px;
+                font-size: 14px;
+            }
+
+            .container {
+                padding: 15px;
+            }
+
+            h1 {
+                font-size: 1.5em;
+            }
+
+            .theme-selector {
+                flex-direction: column;
+                gap: 5px;
+            }
+
+            .app-footer-links {
+                display: flex;
+                flex-direction: column;
+                gap: 8px;
+            }
+
+            .app-footer-links a:not(:last-child)::after {
+                content: none;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
Comprehensive mobile CSS improvements for screens under 768px.

## Problem
The app had display issues on mobile devices as shown in issue #44.

## Solution
Added extensive mobile-specific CSS rules to improve the layout on small screens.

## Changes

### User Header
- Stack vertically instead of horizontal
- Center-align user info and actions

### Todo Items
- Enable flex-wrap for better content flow
- Full-width text area
- Smaller badges with reduced padding
- Full-width delete button at bottom

### Modals
- 95% width with smaller padding
- Full-width buttons stacked vertically

### General
- Reduced container padding (15px)
- Smaller heading font size
- Vertical stats layout
- Vertical theme selector
- Footer links as vertical list

## Testing
- [x] Tested at 768px breakpoint
- [x] Tested at 375px (iPhone SE)
- [x] All elements remain accessible
- [x] Touch targets adequate size

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)