### PR TITLE
Fix: Add email field to unlock modal for password manager recognition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1085,6 +1085,16 @@
                         <p style="color: #666; margin-bottom: 15px;">
                             Enter your password to decrypt your data. Your password is used locally to unlock your encrypted todos and categories.
                         </p>
+                        <label for="unlockEmail">Email</label>
+                        <input
+                            type="email"
+                            id="unlockEmail"
+                            autocomplete="email"
+                            readonly
+                            style="background-color: #f5f5f5; color: #666;"
+                        >
+                    </div>
+                    <div>
                         <label for="unlockPassword">Password</label>
                         <input
                             type="password"
@@ -1256,6 +1266,7 @@
                 this.unlockModal = document.getElementById('unlockModal')
                 this.unlockForm = document.getElementById('unlockForm')
                 this.unlockPassword = document.getElementById('unlockPassword')
+                this.unlockEmail = document.getElementById('unlockEmail')
                 this.unlockError = document.getElementById('unlockError')
                 this.unlockBtn = document.getElementById('unlockBtn')
                 this.unlockLogoutBtn = document.getElementById('unlockLogoutBtn')
@@ -1469,6 +1480,7 @@
             showUnlockModal() {
                 this.unlockModal.classList.add('active')
                 this.unlockError.style.display = 'none'
+                this.unlockEmail.value = this.pendingUser?.email || ''
                 this.unlockPassword.value = ''
                 setTimeout(() => this.unlockPassword.focus(), 100)
             }


### PR DESCRIPTION
## Summary
- Added a readonly email input to the unlock modal, pre-filled with the user's email
- Password managers now recognize the email+password pair and can offer autofill
- Fixes the issue where users had to logout and login again after session timeout because password managers didn't work on the unlock modal

## Test plan
- [ ] Open the app on mobile Safari
- [ ] Wait for session timeout or manually trigger the unlock modal
- [ ] Verify the email field shows the user's email address
- [ ] Confirm password manager offers to autofill credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)