### PR TITLE
Fix: Lock/unlock flow and password manager recognition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1105,9 +1105,7 @@
                         <input
                             type="email"
                             id="unlockEmail"
-                            autocomplete="email"
-                            readonly
-                            style="background-color: #f5f5f5; color: #666;"
+                            autocomplete="username email"
                         >
                     </div>
                     <div>
@@ -1563,9 +1561,12 @@
                     // Initialize encryption with the verified password
                     await this.initializeEncryption(this.pendingUser, password)
 
+                    // Save user reference before closing modal (closeUnlockModal clears pendingUser)
+                    const user = this.pendingUser
+
                     // Close modal and proceed to app
                     this.closeUnlockModal()
-                    this.handleAuthSuccess(this.pendingUser)
+                    this.handleAuthSuccess(user)
                 } catch (e) {
                     console.error('Unlock error:', e)
                     this.unlockError.textContent = 'Failed to unlock. Please try again.'


### PR DESCRIPTION
## Summary
- Fixed unlock not working after manual lock (app was showing blank screen)
- Fixed Safari password manager not offering auto-fill on the unlock modal
- Removed readonly attribute from email field to enable password manager recognition

## Root cause
1. **Blank screen bug**: `closeUnlockModal()` was clearing `pendingUser` before `handleAuthSuccess()` used it, causing null reference
2. **Password manager bug**: The `readonly` attribute on the email field prevented Safari from recognizing it as a login form

## Test plan
- [ ] Log in to the application
- [ ] Click the lock button (🔒)
- [ ] Verify Safari password manager offers to fill credentials
- [ ] Click unlock and verify the app works normally with todos/categories visible
- [ ] Test logout from unlock modal still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)