### PR TITLE
Fix: Persist session across page reloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1303,9 +1303,25 @@
                 const { data: { session } } = await supabase.auth.getSession()
 
                 if (session) {
-                    // Show unlock modal to get password for encryption key
-                    this.pendingUser = session.user
-                    this.showUnlockModal()
+                    // Check if we have a stored password from a previous page load
+                    const storedPassword = sessionStorage.getItem('_ep')
+                    if (storedPassword) {
+                        // Auto-unlock using stored password
+                        try {
+                            await this.initializeEncryption(session.user, storedPassword)
+                            this.handleAuthSuccess(session.user)
+                        } catch (e) {
+                            // If auto-unlock fails, clear stored password and show modal
+                            console.error('Auto-unlock failed:', e)
+                            sessionStorage.removeItem('_ep')
+                            this.pendingUser = session.user
+                            this.showUnlockModal()
+                        }
+                    } else {
+                        // No stored password, show unlock modal
+                        this.pendingUser = session.user
+                        this.showUnlockModal()
+                    }
                 }
 
                 // Listen for auth changes (only for sign out, sign in handled by login form)
@@ -1428,6 +1444,8 @@
                     this.showMessage(error.message, 'error')
                 } else {
                     await this.initializeEncryption(data.user, password)
+                    // Store password in sessionStorage for page reload persistence
+                    sessionStorage.setItem('_ep', password)
                     this.handleAuthSuccess(data.user)
                 }
             }
@@ -1486,6 +1504,7 @@
                 this.categories = []
                 this.priorities = []
                 this.selectedCategoryId = null
+                sessionStorage.removeItem('_ep')
                 this.authContainer.classList.add('active')
                 this.appContainer.classList.remove('active')
                 this.mainContainer.classList.add('auth-mode')
@@ -1499,11 +1518,12 @@
                 // Store current user for unlock verification
                 this.pendingUser = this.currentUser
 
-                // Clear sensitive data from memory
+                // Clear sensitive data from memory and storage
                 this.encryptionKey = null
                 this.todos = []
                 this.categories = []
                 this.priorities = []
+                sessionStorage.removeItem('_ep')
 
                 // Clear the UI
                 this.todoList.innerHTML = ''
@@ -1560,6 +1580,9 @@
 
                     // Initialize encryption with the verified password
                     await this.initializeEncryption(this.pendingUser, password)
+
+                    // Store password in sessionStorage for page reload persistence
+                    sessionStorage.setItem('_ep', password)
 
                     // Save user reference before closing modal (closeUnlockModal clears pendingUser)
                     const user = this.pendingUser


### PR DESCRIPTION
## Summary
- Store password in sessionStorage after successful login/unlock
- On page reload, auto-unlock using stored password instead of showing unlock modal
- Clear stored password when manually locking or logging out

## Security considerations
- Password stored in `sessionStorage` (per-tab, automatically cleared when tab closes)
- Manual lock clears the stored password, requiring re-entry
- Logout clears the stored password
- If auto-unlock fails (e.g., password changed), falls back to showing unlock modal

## Test plan
- [ ] Log in to the application
- [ ] Reload the page - should NOT show unlock modal, app should work normally
- [ ] Click lock button - should show unlock modal
- [ ] Enter password to unlock
- [ ] Reload page again - should NOT show unlock modal (password re-stored after unlock)
- [ ] Close browser tab and reopen - SHOULD show unlock modal (sessionStorage cleared)
- [ ] Log out and log back in - should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)