### PR TITLE
Fix: Prevent login form flash on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,16 @@
             box-sizing: border-box;
         }
 
+        /* Loading state - prevents flash of wrong content */
+        .container.loading {
+            opacity: 0;
+        }
+
+        .container.loaded {
+            opacity: 1;
+            transition: opacity 0.3s ease-in-out;
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
             background: linear-gradient(135deg, var(--primary-start) 0%, var(--primary-end) 100%);
@@ -1418,11 +1428,11 @@
     </style>
 </head>
 <body>
-    <div class="container auth-mode" id="mainContainer">
+    <div class="container auth-mode loading" id="mainContainer">
         <h1>📝 TodoList</h1>
 
         <!-- Authentication UI -->
-        <div id="authContainer" class="auth-container active">
+        <div id="authContainer" class="auth-container">
             <div class="auth-tabs">
                 <button class="auth-tab active" data-tab="login">Login</button>
                 <button class="auth-tab" data-tab="signup">Sign Up</button>
@@ -1846,7 +1856,14 @@
                         this.pendingUser = session.user
                         this.showUnlockModal()
                     }
+                } else {
+                    // No session, show auth container
+                    this.authContainer.classList.add('active')
                 }
+
+                // Remove loading state and show content with transition
+                this.mainContainer.classList.remove('loading')
+                this.mainContainer.classList.add('loaded')
 
                 // Listen for auth changes (only for sign out, sign in handled by login form)
                 supabase.auth.onAuthStateChange((event, session) => {


### PR DESCRIPTION
## Summary
- Prevent the login form from flashing briefly when reloading the page
- Add smooth fade-in transition when content appears

## Problem
When reloading the page with a valid session, the login form would flash briefly before the app loaded. This happened because:
1. HTML initially showed the auth container
2. JavaScript then checked for session and switched to app view

## Solution
- Add `.loading` class to container that sets `opacity: 0`
- Remove `active` class from authContainer in HTML
- JavaScript adds `active` to authContainer only if no session exists
- After auth state is determined, swap `.loading` for `.loaded` class
- `.loaded` class has `opacity: 1` with `0.3s ease-in-out` transition

## Test plan
- [ ] Reload page when logged in with stored password - should fade in smoothly, no flash
- [ ] Reload page when logged in without stored password - unlock modal appears smoothly
- [ ] Load page when logged out - login form appears smoothly
- [ ] Test transition looks smooth, not jarring

🤖 Generated with [Claude Code](https://claude.com/claude-code)