### PR TITLE
Fix: Reload todos after drag-and-drop to refresh UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -3407,12 +3407,8 @@
                     return
                 }
 
-                // Update local state
-                const todo = this.todos.find(t => t.id === todoId)
-                if (todo) {
-                    todo.category_id = categoryId
-                }
-                this.renderTodos()
+                // Reload todos to ensure UI is in sync
+                await this.loadTodos()
             }
 
             async updateTodoContext(todoId, contextId) {
@@ -3427,12 +3423,8 @@
                     return
                 }
 
-                // Update local state
-                const todo = this.todos.find(t => t.id === todoId)
-                if (todo) {
-                    todo.context_id = contextId
-                }
-                this.renderTodos()
+                // Reload todos to ensure UI is in sync
+                await this.loadTodos()
             }
 
             async updateTodoGtdStatus(todoId, gtdStatus) {
@@ -3447,12 +3439,8 @@
                     return
                 }
 
-                // Update local state
-                const todo = this.todos.find(t => t.id === todoId)
-                if (todo) {
-                    todo.gtd_status = gtdStatus
-                }
-                this.renderTodos()
+                // Reload todos to ensure UI is in sync
+                await this.loadTodos()
             }
 
             getFilteredTodos() {


### PR DESCRIPTION
## Summary
- Fix UI not refreshing after drag-and-drop operations
- Changed update methods to reload todos from database instead of manually updating local state

## Test plan
- [ ] Drag a todo to a category and verify UI updates immediately
- [ ] Drag a todo to a GTD tab and verify badge changes immediately
- [ ] Drag a todo to a context and verify badge changes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)