### PR TITLE
Feature: Toggle category/context filter on click

### DIFF
--- a/index.html
+++ b/index.html
@@ -2890,7 +2890,12 @@
             }
 
             selectContext(contextId) {
-                this.selectedContextId = contextId
+                // Toggle: clicking already-selected context deselects it (shows all)
+                if (this.selectedContextId === contextId) {
+                    this.selectedContextId = null
+                } else {
+                    this.selectedContextId = contextId
+                }
                 this.renderContexts()
                 this.renderTodos()
             }
@@ -3093,11 +3098,16 @@
             }
 
             selectCategory(categoryId) {
-                this.selectedCategoryId = categoryId
+                // Toggle: clicking already-selected category deselects it (shows all)
+                if (this.selectedCategoryId === categoryId) {
+                    this.selectedCategoryId = null
+                } else {
+                    this.selectedCategoryId = categoryId
+                }
 
                 // Pre-select category in modal when opening
-                if (categoryId && categoryId !== 'uncategorized') {
-                    this.modalCategorySelect.value = categoryId
+                if (this.selectedCategoryId && this.selectedCategoryId !== 'uncategorized') {
+                    this.modalCategorySelect.value = this.selectedCategoryId
                 } else {
                     this.modalCategorySelect.value = ''
                 }


### PR DESCRIPTION
## Summary
- Clicking an already-selected category deselects it (shows all todos)
- Clicking an already-selected context deselects it (shows all contexts)
- Provides quick way to clear filters without scrolling to "All" option

## Test plan
- [ ] Select a category, click it again - should show all todos
- [ ] Select "Uncategorized", click it again - should show all todos
- [ ] Select a context, click it again - should show all contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)