### PR TITLE
Fix: Update lock icon to match glass color scheme (fixes #58)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1580,15 +1580,15 @@
         }
 
         [data-theme="glass"] .lock-btn {
-            background: var(--ios-orange);
-            color: #ffffff;
+            background: var(--ios-gray5);
+            color: var(--ios-label);
             border: none;
             border-radius: 8px;
             transition: background 0.15s ease;
         }
 
         [data-theme="glass"] .lock-btn:hover {
-            background: #e68600;
+            background: var(--ios-gray4);
         }
 
         [data-theme="glass"] .logout-btn {


### PR DESCRIPTION
## Summary
Updates the lock button styling in the glass theme to use gray tones instead of orange, creating a more cohesive appearance with the rest of the UI.

## Problem
The lock icon was using an orange background (`var(--ios-orange)`) which stood out too prominently and didn't match the subtle, translucent aesthetic of the glass theme.

## Solution
Changed the lock button styling to match the settings button, using gray tones that blend better with the glass UI:
- Background: `var(--ios-orange)` → `var(--ios-gray5)`
- Text color: `#ffffff` → `var(--ios-label)` 
- Hover state: `#e68600` → `var(--ios-gray4)`

## Changes
- Modified `[data-theme="glass"] .lock-btn` CSS styles in `index.html`

## Testing
- [x] Visual inspection in glass theme
- [x] Hover state works correctly

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)