### PR TITLE
Feature: Add Done GTD status

### DIFF
--- a/index.html
+++ b/index.html
@@ -1192,6 +1192,11 @@
             color: #7b1fa2;
         }
 
+        .todo-gtd-badge.done {
+            background: #e8f5e9;
+            color: #2e7d32;
+        }
+
         /* Context Badge */
         .todo-context-badge {
             padding: 4px 10px;
@@ -1836,6 +1841,11 @@
             color: #af52de;
         }
 
+        [data-theme="glass"] .todo-gtd-badge.done {
+            background: rgba(52, 199, 89, 0.15);
+            color: #34c759;
+        }
+
         /* iOS Context Badge */
         [data-theme="glass"] .todo-context-badge {
             background: var(--ios-gray5);
@@ -1940,6 +1950,7 @@
                         <button class="gtd-tab" data-status="next_action" role="tab" aria-selected="false">Next</button>
                         <button class="gtd-tab" data-status="waiting_for" role="tab" aria-selected="false">Waiting</button>
                         <button class="gtd-tab" data-status="someday_maybe" role="tab" aria-selected="false">Someday</button>
+                        <button class="gtd-tab" data-status="done" role="tab" aria-selected="false">Done</button>
                     </div>
 
                     <ul id="todoList" class="todo-list"></ul>
@@ -2025,6 +2036,7 @@
                             <option value="next_action">Next Action</option>
                             <option value="waiting_for">Waiting For</option>
                             <option value="someday_maybe">Someday/Maybe</option>
+                            <option value="done">Done</option>
                         </select>
                     </div>
                     <div>
@@ -3469,8 +3481,15 @@
                 }
 
                 // Filter by GTD status
-                if (this.selectedGtdStatus !== 'all') {
+                if (this.selectedGtdStatus === 'done') {
+                    // Show only done items when Done tab is selected
+                    filtered = filtered.filter(t => t.gtd_status === 'done')
+                } else if (this.selectedGtdStatus !== 'all') {
+                    // Show items matching the selected status (excludes done)
                     filtered = filtered.filter(t => t.gtd_status === this.selectedGtdStatus)
+                } else {
+                    // 'all' - exclude done items from the normal view
+                    filtered = filtered.filter(t => t.gtd_status !== 'done')
                 }
 
                 // Sort by priority level (lower level = higher priority)
@@ -3504,7 +3523,8 @@
                     'inbox': 'Inbox',
                     'next_action': 'Next',
                     'waiting_for': 'Waiting',
-                    'someday_maybe': 'Someday'
+                    'someday_maybe': 'Someday',
+                    'done': 'Done'
                 }
                 return labels[status] || status
             }

--- a/migrations/007_add_done_gtd_status.sql
+++ b/migrations/007_add_done_gtd_status.sql
@@ -1,0 +1,5 @@
+-- Add 'done' to the gtd_status options
+-- Note: PostgreSQL text columns don't enforce enum values,
+-- the constraint is in the application layer
+
+COMMENT ON COLUMN todos.gtd_status IS 'GTD workflow status: inbox (unprocessed), next_action (ready to do), waiting_for (delegated/blocked), someday_maybe (future possibilities), done (completed)';


### PR DESCRIPTION
## Summary
Adds a new "Done" GTD status that hides completed todos from normal lists, with a dedicated tab to view them.

## Problem
Users needed a way to mark todos as "done" in the GTD workflow while keeping them separate from the active todo lists. The existing completion checkbox marks items as done but they still appear in all views.

## Solution
Added a new "Done" GTD status that:
- Hides done todos from All, Inbox, Next, Waiting, and Someday views
- Shows done todos only when the Done tab is selected
- Provides a clear separation between active and completed work

## Changes
- `index.html`:
  - Added "Done" tab to GTD status filter tabs
  - Added "Done" option to modal GTD status dropdown
  - Updated `getFilteredTodos()` to hide done items from normal views
  - Added CSS styling for done badge (green theme, both default and glass)
  - Updated `getGtdStatusLabel()` to include 'done' mapping
- `migrations/007_add_done_gtd_status.sql`: Database migration documenting the new status

## Testing
- [x] Done tab appears after Someday
- [x] Todos can be set to "Done" status via modal dropdown
- [x] Done todos don't appear in All, Inbox, Next, Waiting, or Someday views
- [x] Done todos appear when Done tab is selected
- [x] Badge styling works in both default and glass themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)