### PR TITLE
Fix: Replace legacy GitHub Pages deployment with Actions workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  workflow_run:
+    workflows: ["Auto Version Bump"]
+    types: [completed]
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    # Deploy when:
+    # - Version bump succeeded, OR
+    # - Direct push to main (not a PR merge that triggers version bump)
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'push' &&
+       !contains(github.event.head_commit.message, 'Merge pull request') &&
+       !contains(github.event.head_commit.message, '(#'))
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`deploy-pages.yml`) to control GitHub Pages deployments
- Fixes the issue where every PR merge triggered two deployments (first one getting cancelled)

## Problem
Every PR merge was triggering:
1. GitHub Pages deployment from the merge commit
2. Auto-version-bump pushes a new commit
3. Second GitHub Pages deployment from the version bump (cancelling the first)

## Solution
The new workflow triggers deployment:
- After `Auto Version Bump` workflow completes successfully (for PR merges)
- On direct pushes to main (that don't trigger version bump)

## Required Manual Step After Merge
**IMPORTANT:** After merging this PR, you must change GitHub Pages settings:
1. Go to **Settings → Pages**
2. Under "Build and deployment", change Source from **"Deploy from a branch"** to **"GitHub Actions"**

## Test plan
- [ ] Merge this PR
- [ ] Change GitHub Pages settings to use "GitHub Actions" as source
- [ ] Merge another PR and verify only ONE deployment runs (after version bump completes)
- [ ] Verify the site is deployed correctly at https://radekcap.github.io/todolist/

🤖 Generated with [Claude Code](https://claude.com/claude-code)