### PR TITLE
Fix: Make sidebar sections collapsed by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -2008,9 +2008,9 @@
             <div class="main-content">
                 <!-- Sidebar with categories -->
                 <div class="sidebar">
-                    <!-- Categories Section -->
-                    <div class="sidebar-section" id="categoriesSection">
-                        <div class="sidebar-section-header" role="button" aria-expanded="true" aria-controls="categoriesContent">
+                    <!-- Categories Section (collapsed by default) -->
+                    <div class="sidebar-section collapsed" id="categoriesSection">
+                        <div class="sidebar-section-header" role="button" aria-expanded="false" aria-controls="categoriesContent">
                             <h2>Categories</h2>
                             <span class="sidebar-section-toggle" aria-hidden="true">▼</span>
                         </div>
@@ -2029,9 +2029,9 @@
                         </div>
                     </div>
 
-                    <!-- Contexts Section -->
-                    <div class="sidebar-section" id="contextsSection">
-                        <div class="sidebar-section-header" role="button" aria-expanded="true" aria-controls="contextsContent">
+                    <!-- Contexts Section (collapsed by default) -->
+                    <div class="sidebar-section collapsed" id="contextsSection">
+                        <div class="sidebar-section-header" role="button" aria-expanded="false" aria-controls="contextsContent">
                             <h2 class="contexts-header">Contexts</h2>
                             <span class="sidebar-section-toggle" aria-hidden="true">▼</span>
                         </div>


### PR DESCRIPTION
## Summary
Categories and Contexts sections now start collapsed when the page loads or after logging in.

## Test plan
- [ ] Load the page - both sections should be collapsed
- [ ] Log out and log in - sections should be collapsed
- [ ] Click to expand - should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)