### PR TITLE
Fix: Todo list border fully visible in glass theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1538,6 +1538,7 @@
             border-radius: 12px;
             overflow: hidden;
             box-shadow: 0 0 0 0.5px var(--ios-separator);
+            margin: 1px;
         }
 
         [data-theme="glass"] .todo-item {


### PR DESCRIPTION
## Summary
Fixes the missing left and top border lines on the todo list in glass theme.

## Problem
The `box-shadow: 0 0 0 0.5px` used to create the border outline was being clipped on the left and top sides.

## Solution
Added `margin: 1px` to the todo-list in glass theme to ensure the box-shadow has space to render on all sides.

## Test plan
- [ ] Open app in glass theme
- [ ] Verify todo list has complete border on all 4 sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)