### PR TITLE
Fix: Left border visibility on todo list in glass theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1532,6 +1532,11 @@
             background: var(--ios-blue-hover);
         }
 
+        /* iOS Content Area - padding to prevent box-shadow clipping */
+        [data-theme="glass"] .content {
+            padding-left: 1px;
+        }
+
         /* iOS Todo Items - Grouped list style */
         [data-theme="glass"] .todo-list {
             background: var(--ios-bg-secondary);


### PR DESCRIPTION
## Summary
Fixes the missing left border line on the todo list in glass theme.

## Problem
The left side of the `box-shadow` border was being clipped by the content area edge.

## Solution
Added `padding-left: 1px` to the content area in glass theme.

## Test plan
- [ ] Open app in glass theme
- [ ] Verify todo list has complete border on all 4 sides (including left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)