### PR TITLE
Fix: Remove gray border between Categories and Contexts sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1145,9 +1145,7 @@
 
         /* Contexts section in sidebar */
         .contexts-header {
-            margin-top: 25px;
-            padding-top: 20px;
-            border-top: 1px solid #e0e0e0;
+            /* No special styling needed - sections have margin via .sidebar-section */
         }
 
         .context-list {
@@ -1846,7 +1844,6 @@
         /* iOS Contexts Section */
         [data-theme="glass"] .contexts-header {
             color: var(--ios-label-secondary);
-            border-top-color: var(--ios-separator);
         }
 
         [data-theme="glass"] .context-list {


### PR DESCRIPTION
## Summary
- Removes the `border-top` from `.contexts-header` that was causing a gray line to appear between the collapsed Categories and Contexts sidebar sections
- Sections already have proper visual separation via `.sidebar-section` margin-bottom

## Test plan
- [ ] Collapse both Categories and Contexts sections - verify no gray line appears between them
- [ ] Expand both sections - verify proper spacing is maintained
- [ ] Test with Glass theme to ensure no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)