### PR TITLE
Fix: Prevent content jumping when switching GTD statuses

### DIFF
--- a/index.html
+++ b/index.html
@@ -715,6 +715,7 @@
 
         .todo-list {
             list-style: none;
+            min-height: 280px;
         }
 
         .todo-item {


### PR DESCRIPTION
## Summary
- Added `min-height: 280px` to `.todo-list` container
- Prevents layout shifts between inbox zen state (large illustration) and regular empty states

## Problem
The inbox empty state has a large illustration (~280px tall), while other GTD statuses show a smaller empty message (~100px). Switching between them caused the content to "jump".

## Solution
Set a consistent minimum height that accommodates the largest empty state (inbox zen).

## Test plan
- [ ] Switch between Inbox, Next, Waiting, Someday, Done with empty lists
- [ ] Verify no layout jumping occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)