### PR TITLE
Fix: Increase min-height to match inbox zen state

### DIFF
--- a/index.html
+++ b/index.html
@@ -715,7 +715,7 @@
 
         .todo-list {
             list-style: none;
-            min-height: 280px;
+            min-height: 360px;
         }
 
         .todo-item {


### PR DESCRIPTION
## Summary
Increased `.todo-list` min-height from 280px to 360px to fully match the inbox zen state height.

## Problem
The inbox zen state is taller than initially calculated:
- 120px vertical padding
- 120px illustration
- ~120px for gaps, title, and message

280px was not enough, causing layout shift when switching between Inbox and other empty GTD statuses.

## Test plan
- [ ] Switch between empty Inbox and empty Next - no jumping
- [ ] Switch between all empty GTD statuses - consistent height

🤖 Generated with [Claude Code](https://claude.com/claude-code)