### PR TITLE
Pre-fill selected project when adding new todo

### DIFF
--- a/index.html
+++ b/index.html
@@ -3771,6 +3771,13 @@
                     this.modalCategorySelect.value = ''
                 }
 
+                // Pre-select project if one is selected in the sidebar
+                if (this.selectedProjectId !== null) {
+                    this.modalProjectSelect.value = this.selectedProjectId
+                } else {
+                    this.modalProjectSelect.value = ''
+                }
+
                 // Handle Escape key to close modal
                 this.handleEscapeKey = (e) => {
                     if (e.key === 'Escape') this.closeModal()


### PR DESCRIPTION
## Summary
- When a project is selected in the sidebar, the add todo modal now pre-fills that project automatically
- This matches the existing behavior for categories, providing a consistent UX
- Makes it faster to add todos to the currently viewed project

## Test plan
- [ ] Select a project in the sidebar
- [ ] Click "+ Add New Todo" button
- [ ] Verify the project dropdown is pre-filled with the selected project
- [ ] With no project selected, verify the dropdown defaults to "No Project"

🤖 Generated with [Claude Code](https://claude.com/claude-code)