### PR TITLE
Fix Safari border clipping on GTD list items

### DIFF
--- a/index.html
+++ b/index.html
@@ -1217,6 +1217,7 @@
 
         .gtd-list {
             list-style: none;
+            padding-left: 1px; /* Prevents Safari from clipping left border of items with border-radius */
         }
 
         .gtd-item {


### PR DESCRIPTION
## Summary
- Fixes left border/background clipping of GTD list items in Safari
- Safari clips elements with `border-radius` when the container has no padding
- Added 1px left padding to `.gtd-list` to prevent the clipping

## Test plan
- [ ] Open in Safari
- [ ] Select "Inbox" or any other GTD status in the sidebar
- [ ] Verify the left edge of the active item's gradient background renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)