### PR TITLE
Fix Safari box-shadow border clipping in Glass theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1570,6 +1570,7 @@
         /* iOS Sidebar */
         [data-theme="glass"] .sidebar {
             background: transparent;
+            padding: 1px; /* Prevents Safari from clipping box-shadow on child lists */
         }
 
         [data-theme="glass"] .sidebar h2 {


### PR DESCRIPTION
## Summary
- Fixes left and bottom border clipping of sidebar lists in Safari when using Glass theme
- Safari clips `box-shadow` that extends outside the parent container bounds
- Added 1px padding to the sidebar container to prevent clipping on all edges
- Affects all sidebar lists: GTD, categories, contexts, and projects

## Root cause
The Glass theme uses `box-shadow: 0 0 0 0.5px var(--ios-separator)` to simulate thin borders on lists. This box-shadow extends outside the element bounds, and Safari clips it when the parent container has no padding.

## Test plan
- [ ] Open in Safari with Glass theme selected
- [ ] Verify left edge of GTD list border renders correctly
- [ ] Collapse Projects section and verify bottom edge of GTD list border renders correctly
- [ ] Check that category, context, and project lists also render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)