### PR TITLE
Fix Safari box-shadow rendering with GPU compositing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1593,6 +1593,7 @@
             border-radius: 12px;
             overflow: hidden;
             box-shadow: 0 0 0 0.5px var(--ios-separator);
+            transform: translateZ(0); /* Force GPU compositing to fix Safari box-shadow rendering */
         }
 
         [data-theme="glass"] .category-item {
@@ -1663,6 +1664,7 @@
             border-radius: 12px;
             overflow: hidden;
             box-shadow: 0 0 0 0.5px var(--ios-separator);
+            transform: translateZ(0); /* Force GPU compositing to fix Safari box-shadow rendering */
         }
 
         [data-theme="glass"] .project-item {
@@ -2021,6 +2023,7 @@
             border-radius: 12px;
             overflow: hidden;
             box-shadow: 0 0 0 0.5px var(--ios-separator);
+            transform: translateZ(0); /* Force GPU compositing to fix Safari box-shadow rendering */
         }
 
         [data-theme="glass"] .gtd-item {
@@ -2073,6 +2076,7 @@
             border-radius: 12px;
             overflow: hidden;
             box-shadow: 0 0 0 0.5px var(--ios-separator);
+            transform: translateZ(0); /* Force GPU compositing to fix Safari box-shadow rendering */
         }
 
         [data-theme="glass"] .context-item {


### PR DESCRIPTION
## Summary
- Safari has a rendering bug where `box-shadow` on static elements doesn't render until a repaint (e.g., hover)
- Added `transform: translateZ(0)` to force GPU compositing on all sidebar lists in Glass theme
- This ensures proper initial rendering of the thin border effect

## Affected elements
- `.gtd-list`
- `.category-list`
- `.project-list`
- `.context-list`

## Test plan
- [ ] Open in Safari with Glass theme
- [ ] Verify all sidebar list borders render correctly on initial page load (without hovering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)