### PR TITLE
Fix Safari border rendering: use real borders instead of box-shadow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1592,8 +1592,7 @@
             background: var(--ios-bg-secondary);
             border-radius: 12px;
             overflow: hidden;
-            box-shadow: 0 0 0 0.5px var(--ios-separator);
-            transform: translateZ(0); /* Force GPU compositing to fix Safari box-shadow rendering */
+            border: 1px solid var(--ios-separator);
         }
 
         [data-theme="glass"] .category-item {
@@ -1663,8 +1662,7 @@
             background: var(--ios-bg-secondary);
             border-radius: 12px;
             overflow: hidden;
-            box-shadow: 0 0 0 0.5px var(--ios-separator);
-            transform: translateZ(0); /* Force GPU compositing to fix Safari box-shadow rendering */
+            border: 1px solid var(--ios-separator);
         }
 
         [data-theme="glass"] .project-item {
@@ -1739,8 +1737,7 @@
             background: var(--ios-bg-secondary);
             border-radius: 12px;
             overflow: hidden;
-            box-shadow: 0 0 0 0.5px var(--ios-separator);
-            margin: 1px;
+            border: 1px solid var(--ios-separator);
         }
 
         [data-theme="glass"] .todo-item {
@@ -1909,10 +1906,9 @@
 
         [data-theme="glass"] .theme-selector select {
             background: var(--ios-bg-secondary);
-            border: none;
+            border: 1px solid var(--ios-separator);
             border-radius: 8px;
             color: var(--ios-label);
-            box-shadow: 0 0 0 0.5px var(--ios-separator);
             padding: 8px 12px;
         }
 
@@ -2022,8 +2018,7 @@
             background: var(--ios-bg-secondary);
             border-radius: 12px;
             overflow: hidden;
-            box-shadow: 0 0 0 0.5px var(--ios-separator);
-            transform: translateZ(0); /* Force GPU compositing to fix Safari box-shadow rendering */
+            border: 1px solid var(--ios-separator);
         }
 
         [data-theme="glass"] .gtd-item {
@@ -2075,8 +2070,7 @@
             background: var(--ios-bg-secondary);
             border-radius: 12px;
             overflow: hidden;
-            box-shadow: 0 0 0 0.5px var(--ios-separator);
-            transform: translateZ(0); /* Force GPU compositing to fix Safari box-shadow rendering */
+            border: 1px solid var(--ios-separator);
         }
 
         [data-theme="glass"] .context-item {


### PR DESCRIPTION
## Summary
- Safari has persistent rendering issues with `box-shadow: 0 0 0 0.5px` used to simulate thin borders
- Previous fixes (padding, transform: translateZ(0)) didn't fully resolve the issue
- Replaced all box-shadow border simulations with real `border: 1px solid` which Safari renders reliably

## Affected elements
- `.gtd-list`
- `.category-list`
- `.project-list`
- `.context-list`
- `.todo-list`
- `.theme-selector select`

## Test plan
- [ ] Open in Safari with Glass theme
- [ ] Verify all borders render correctly on initial page load
- [ ] Check GTD list, category list, project list, context list, and todo list

🤖 Generated with [Claude Code](https://claude.com/claude-code)