### PR TITLE
Add padding for input focus outline in Glass theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1625,7 +1625,7 @@
 
         [data-theme="glass"] .add-category-form {
             border-top: none;
-            padding-top: 20px;
+            padding: 20px 5px 0 5px; /* Horizontal padding for input focus outline */
         }
 
         [data-theme="glass"] .add-category-input {
@@ -1695,7 +1695,7 @@
 
         [data-theme="glass"] .add-project-form {
             border-top: none;
-            padding-top: 20px;
+            padding: 20px 5px 0 5px; /* Horizontal padding for input focus outline */
         }
 
         [data-theme="glass"] .add-project-input {
@@ -2104,6 +2104,10 @@
             color: white !important;
             transform: scale(1.02);
             box-shadow: 0 2px 8px rgba(0, 122, 255, 0.3);
+        }
+
+        [data-theme="glass"] .add-context-form {
+            padding: 0 5px; /* Horizontal padding for input focus outline */
         }
 
         [data-theme="glass"] .add-context-input {


### PR DESCRIPTION
## Summary
- The 4px focus outline was getting clipped on the sides of input fields
- Added 5px horizontal padding to form containers to give room for the outline

## Affected forms
- `.add-category-form`
- `.add-project-form`
- `.add-context-form`

## Test plan
- [ ] Open in Safari with Glass theme
- [ ] Click on "New category..." input
- [ ] Verify focus outline renders fully on all sides
- [ ] Check same for project and context inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)