### PR TITLE
Click on todo text to open edit modal (fixes #90)

### DIFF
--- a/index.html
+++ b/index.html
@@ -885,6 +885,7 @@
             color: #333;
             font-size: 16px;
             word-break: break-word;
+            cursor: pointer;
         }
 
         .todo-item.completed .todo-text {
@@ -4314,6 +4315,10 @@
 
                         const checkbox = li.querySelector('.todo-checkbox')
                         checkbox.addEventListener('change', () => this.toggleTodo(todo.id))
+
+                        // Click on todo text opens edit modal
+                        const todoText = li.querySelector('.todo-text')
+                        todoText.addEventListener('click', () => this.openEditModal(todo.id))
 
                         const editBtn = li.querySelector('.edit-btn')
                         editBtn.addEventListener('click', () => this.openEditModal(todo.id))


### PR DESCRIPTION
## Summary
Implements the ability to click directly on todo text to open the edit form.

## Problem
Previously, users had to click the "Edit" button to edit a todo item. This required precise targeting of a small button.

## Solution
Added a click event listener to the `.todo-text` element that opens the edit modal when clicked.

## Changes
- Added click handler to `.todo-text` that calls `openEditModal(todo.id)`
- Added `cursor: pointer` style to `.todo-text` to indicate clickability

## Testing
- [x] Click on todo text opens edit modal
- [x] Checkbox still works independently
- [x] Edit button still works
- [x] Delete button still works

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)