### PR TITLE
feat: Add comment field to todo items (fixes #91)

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,6 +251,15 @@
                             id="modalDueDateInput"
                         >
                     </div>
+                    <div>
+                        <label for="modalCommentInput">Comment (optional)</label>
+                        <textarea
+                            id="modalCommentInput"
+                            placeholder="Add additional notes or details..."
+                            maxlength="1024"
+                            rows="3"
+                        ></textarea>
+                    </div>
                     <div class="modal-actions">
                         <button type="button" id="cancelModal" class="modal-btn modal-btn-secondary">Cancel</button>
                         <button type="submit" id="modalAddBtn" class="modal-btn modal-btn-primary">Add Todo</button>

--- a/migrations/008_add_comment_to_todos.sql
+++ b/migrations/008_add_comment_to_todos.sql
@@ -1,0 +1,8 @@
+-- Add comment column to todos table for additional notes/details
+-- The comment field is encrypted client-side like the todo text
+
+ALTER TABLE todos
+ADD COLUMN IF NOT EXISTS comment TEXT;
+
+-- Add comment
+COMMENT ON COLUMN todos.comment IS 'Encrypted comment/notes for the todo item (nullable, max 1024 chars client-side)';

--- a/styles.css
+++ b/styles.css
@@ -892,17 +892,33 @@ h1 {
     accent-color: var(--accent-color);
 }
 
-.todo-text {
+.todo-content {
     flex: 1;
+    min-width: 0;
+}
+
+.todo-text {
     color: #333;
     font-size: 16px;
     word-break: break-word;
     cursor: pointer;
 }
 
+.todo-comment {
+    font-size: 13px;
+    color: #666;
+    margin-top: 4px;
+    line-height: 1.4;
+    word-break: break-word;
+}
+
 .todo-item.completed .todo-text {
     text-decoration: line-through;
     color: #999;
+}
+
+.todo-item.completed .todo-comment {
+    color: #aaa;
 }
 
 .todo-category-badge {
@@ -1120,7 +1136,8 @@ h1 {
 }
 
 .modal-form input,
-.modal-form select {
+.modal-form select,
+.modal-form textarea {
     width: 100%;
     padding: 12px 15px;
     border: 2px solid #e0e0e0;
@@ -1129,8 +1146,15 @@ h1 {
     box-sizing: border-box;
 }
 
+.modal-form textarea {
+    resize: vertical;
+    min-height: 60px;
+    font-family: inherit;
+}
+
 .modal-form input:focus,
-.modal-form select:focus {
+.modal-form select:focus,
+.modal-form textarea:focus {
     outline: none;
     border-color: var(--accent-color);
 }
@@ -1519,7 +1543,8 @@ h1 {
 [data-theme="glass"] .form-group input,
 [data-theme="glass"] .form-group select,
 [data-theme="glass"] .modal-form input,
-[data-theme="glass"] .modal-form select {
+[data-theme="glass"] .modal-form select,
+[data-theme="glass"] .modal-form textarea {
     background: var(--ios-bg-secondary);
     border: 1px solid var(--ios-separator);
     border-radius: 10px;
@@ -1532,7 +1557,8 @@ h1 {
 [data-theme="glass"] .form-group input:focus,
 [data-theme="glass"] .form-group select:focus,
 [data-theme="glass"] .modal-form input:focus,
-[data-theme="glass"] .modal-form select:focus {
+[data-theme="glass"] .modal-form select:focus,
+[data-theme="glass"] .modal-form textarea:focus {
     background: var(--ios-bg-secondary);
     border-color: var(--ios-blue);
     outline: 4px solid rgba(0, 122, 255, 0.15);
@@ -1540,7 +1566,8 @@ h1 {
 }
 
 [data-theme="glass"] .form-group input::placeholder,
-[data-theme="glass"] .modal-form input::placeholder {
+[data-theme="glass"] .modal-form input::placeholder,
+[data-theme="glass"] .modal-form textarea::placeholder {
     color: var(--ios-label-tertiary);
 }
 
@@ -1796,7 +1823,16 @@ h1 {
     font-size: 17px;
 }
 
+[data-theme="glass"] .todo-comment {
+    color: var(--ios-label-secondary);
+    font-size: 14px;
+}
+
 [data-theme="glass"] .todo-item.completed .todo-text {
+    color: var(--ios-label-tertiary);
+}
+
+[data-theme="glass"] .todo-item.completed .todo-comment {
     color: var(--ios-label-tertiary);
 }
 


### PR DESCRIPTION
## Summary
- Adds a "Comment" textarea field to the todo modal allowing longer notes (up to 1024 chars)
- Comments are encrypted client-side like other todo fields
- Comments display below the todo text in the list view

## Changes
- **index.html**: Added comment textarea to add/edit todo modal
- **app.js**: Handle comment in addTodo, updateTodo, loadTodos, openEditModal methods
- **styles.css**: Added styling for `.todo-comment` in default and Glass themes
- **migrations/008_add_comment_to_todos.sql**: Database migration to add `comment` column

## Database Migration Required
Run the following SQL in Supabase:
```sql
ALTER TABLE todos
ADD COLUMN IF NOT EXISTS comment TEXT;
```

## Test plan
- [x] Run the database migration in Supabase SQL editor
- [ ] Add a new todo with a comment
- [ ] Verify comment appears below todo text in the list
- [ ] Edit an existing todo and add/modify comment
- [ ] Verify comment is encrypted in database
- [ ] Test with Glass theme for proper styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)