### PR TITLE
feat: Add 'Create more' checkbox to add todo modal (fixes #92)

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,6 +148,7 @@ class TodoApp {
         this.modalContextSelect = document.getElementById('modalContextSelect')
         this.modalDueDateInput = document.getElementById('modalDueDateInput')
         this.modalCommentInput = document.getElementById('modalCommentInput')
+        this.createMoreCheckbox = document.getElementById('createMoreCheckbox')
         this.modalAddBtn = document.getElementById('modalAddBtn')
         this.modalTitle = document.getElementById('modalTitle')
         this.todoList = document.getElementById('todoList')
@@ -1264,6 +1265,10 @@ class TodoApp {
         this.modalGtdStatusSelect.value = 'inbox'
         this.modalContextSelect.value = ''
 
+        // Show "Create more" checkbox for new todos
+        this.createMoreCheckbox.closest('.create-more-option').style.display = ''
+        // Preserve checkbox state across multiple additions
+
         // Pre-select category if exactly one is selected (not 'uncategorized')
         if (this.selectedCategoryIds.size === 1) {
             const selectedId = [...this.selectedCategoryIds][0]
@@ -1302,6 +1307,9 @@ class TodoApp {
         this.modalAddBtn.textContent = 'Save Changes'
         this.addTodoModal.classList.add('active')
 
+        // Hide "Create more" checkbox for editing (not applicable)
+        this.createMoreCheckbox.closest('.create-more-option').style.display = 'none'
+
         // Pre-populate fields with existing todo data
         this.modalTodoInput.value = todo.text
         this.modalCategorySelect.value = todo.category_id || ''
@@ -1338,6 +1346,8 @@ class TodoApp {
         this.modalGtdStatusSelect.value = 'inbox'
         this.modalContextSelect.value = ''
         this.modalDueDateInput.value = ''
+        this.modalCommentInput.value = ''
+        this.createMoreCheckbox.checked = false
 
         // Reset modal to add mode
         this.modalTitle.textContent = 'Add New Todo'
@@ -1464,10 +1474,22 @@ class TodoApp {
         }
 
         // Store decrypted text in local state for rendering
-        const todoWithDecryptedText = { ...data[0], text: text }
+        const todoWithDecryptedText = { ...data[0], text: text, comment: comment }
         this.todos.push(todoWithDecryptedText)
-        this.closeModal()
-        this.renderTodos()
+
+        // Handle "Create more" mode
+        if (this.createMoreCheckbox.checked) {
+            // Clear only text and comment fields, keep other selections
+            this.modalTodoInput.value = ''
+            this.modalCommentInput.value = ''
+            this.renderTodos()
+            this.renderGtdList()
+            // Refocus on input for next todo
+            setTimeout(() => this.modalTodoInput.focus(), 100)
+        } else {
+            this.closeModal()
+            this.renderTodos()
+        }
     }
 
     async updateTodo() {

--- a/index.html
+++ b/index.html
@@ -260,6 +260,12 @@
                             rows="3"
                         ></textarea>
                     </div>
+                    <div class="create-more-option">
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="createMoreCheckbox">
+                            <span>Create more</span>
+                        </label>
+                    </div>
                     <div class="modal-actions">
                         <button type="button" id="cancelModal" class="modal-btn modal-btn-secondary">Cancel</button>
                         <button type="submit" id="modalAddBtn" class="modal-btn modal-btn-primary">Add Todo</button>

--- a/styles.css
+++ b/styles.css
@@ -1159,6 +1159,31 @@ h1 {
     border-color: var(--accent-color);
 }
 
+.create-more-option {
+    margin-top: 5px;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-size: 14px;
+    color: #666;
+    user-select: none;
+}
+
+.checkbox-label input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+    accent-color: var(--accent-color);
+}
+
+.checkbox-label span {
+    line-height: 1;
+}
+
 .modal-actions {
     display: flex;
     gap: 10px;
@@ -1618,6 +1643,16 @@ h1 {
 
 [data-theme="glass"] .modal-btn-secondary:hover {
     background: var(--ios-gray4);
+}
+
+/* iOS Checkbox Label */
+[data-theme="glass"] .checkbox-label {
+    color: var(--ios-label-secondary);
+    font-size: 15px;
+}
+
+[data-theme="glass"] .checkbox-label input[type="checkbox"] {
+    accent-color: var(--ios-blue);
 }
 
 /* iOS Sidebar */


### PR DESCRIPTION
## Summary
- Adds a "Create more" checkbox to the add todo modal for batch todo entry
- When checked, saving a todo clears only the text and comment fields
- All other selections (category, project, priority, GTD status, context, due date) are preserved
- Focus returns to the text input for quick entry of the next todo

## Problem
Users who need to add multiple todos with similar properties (same category, project, etc.) had to re-select these options for each new todo, which was tedious.

## Solution
Added a "Create more" checkbox that, when enabled, keeps the modal open after saving and preserves the current field selections. Only the "What needs to be done?" text and "Comment" fields are cleared.

## Changes
- **index.html**: Added "Create more" checkbox with accessible label
- **app.js**: 
  - Added DOM reference for checkbox
  - `openModal()`: Shows the checkbox for new todos
  - `openEditModal()`: Hides the checkbox (not applicable for editing)
  - `closeModal()`: Resets the checkbox
  - `addTodo()`: Handles the "create more" behavior
- **styles.css**: Added styling for `.create-more-option` and `.checkbox-label` in default and Glass themes

## Test plan
- [ ] Open add todo modal, verify checkbox appears
- [ ] Add a todo without checkbox - modal closes normally
- [ ] Check "Create more", add a todo - modal stays open with fields preserved
- [ ] Verify text and comment are cleared but other selections remain
- [ ] Edit a todo - verify checkbox is hidden
- [ ] Test with Glass theme for proper styling

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)