### PR TITLE
feat: Redesign modal form with grouped fields and glass styling (fixes #98)

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,66 +200,87 @@
                     <button id="closeModal" class="modal-close" aria-label="Close modal">&times;</button>
                 </div>
                 <form id="addTodoForm" class="modal-form">
-                    <div>
-                        <label for="modalTodoInput">What needs to be done?</label>
-                        <input
-                            type="text"
-                            id="modalTodoInput"
-                            placeholder="Enter todo description..."
-                            autocomplete="off"
-                            required
-                        >
-                    </div>
-                    <div>
-                        <label for="modalCategorySelect">Category (optional)</label>
-                        <select id="modalCategorySelect">
-                            <option value="">No Category</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label for="modalProjectSelect">Project (optional)</label>
-                        <select id="modalProjectSelect">
-                            <option value="">No Project</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label for="modalPrioritySelect">Priority (optional)</label>
-                        <select id="modalPrioritySelect" aria-label="Priority (optional)">
-                            <option value="">No Priority</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label for="modalGtdStatusSelect">GTD Status</label>
-                        <select id="modalGtdStatusSelect" aria-label="GTD Status">
-                            <option value="inbox">Inbox</option>
-                            <option value="next_action">Next Action</option>
-                            <option value="waiting_for">Waiting For</option>
-                            <option value="someday_maybe">Someday/Maybe</option>
-                            <option value="done">Done</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label for="modalContextSelect">Context (optional)</label>
-                        <select id="modalContextSelect" aria-label="Context (optional)">
-                            <option value="">No Context</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label for="modalDueDateInput">Due Date (optional)</label>
-                        <input
-                            type="date"
-                            id="modalDueDateInput"
-                        >
-                    </div>
-                    <div>
-                        <label for="modalCommentInput">Comment (optional)</label>
-                        <textarea
-                            id="modalCommentInput"
-                            placeholder="Add additional notes or details..."
-                            maxlength="1024"
-                            rows="3"
-                        ></textarea>
-                    </div>
+                    <!-- Task Section -->
+                    <fieldset class="form-section">
+                        <legend class="form-section-title">Task</legend>
+                        <div class="form-field">
+                            <label for="modalTodoInput">What needs to be done?</label>
+                            <input
+                                type="text"
+                                id="modalTodoInput"
+                                placeholder="Enter todo description..."
+                                autocomplete="off"
+                                required
+                            >
+                        </div>
+                        <div class="form-field">
+                            <label for="modalCommentInput">Notes</label>
+                            <textarea
+                                id="modalCommentInput"
+                                placeholder="Add additional notes or details..."
+                                maxlength="1024"
+                                rows="3"
+                            ></textarea>
+                        </div>
+                    </fieldset>
+
+                    <!-- Organization Section -->
+                    <fieldset class="form-section">
+                        <legend class="form-section-title">Organization</legend>
+                        <div class="form-row">
+                            <div class="form-field">
+                                <label for="modalCategorySelect">Category</label>
+                                <select id="modalCategorySelect">
+                                    <option value="">No Category</option>
+                                </select>
+                            </div>
+                            <div class="form-field">
+                                <label for="modalProjectSelect">Project</label>
+                                <select id="modalProjectSelect">
+                                    <option value="">No Project</option>
+                                </select>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <!-- Planning Section -->
+                    <fieldset class="form-section">
+                        <legend class="form-section-title">Planning</legend>
+                        <div class="form-row">
+                            <div class="form-field">
+                                <label for="modalGtdStatusSelect">Status</label>
+                                <select id="modalGtdStatusSelect" aria-label="GTD Status">
+                                    <option value="inbox">Inbox</option>
+                                    <option value="next_action">Next Action</option>
+                                    <option value="waiting_for">Waiting For</option>
+                                    <option value="someday_maybe">Someday/Maybe</option>
+                                    <option value="done">Done</option>
+                                </select>
+                            </div>
+                            <div class="form-field">
+                                <label for="modalPrioritySelect">Priority</label>
+                                <select id="modalPrioritySelect" aria-label="Priority">
+                                    <option value="">No Priority</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-field">
+                                <label for="modalContextSelect">Context</label>
+                                <select id="modalContextSelect" aria-label="Context">
+                                    <option value="">No Context</option>
+                                </select>
+                            </div>
+                            <div class="form-field">
+                                <label for="modalDueDateInput">Due Date</label>
+                                <input
+                                    type="date"
+                                    id="modalDueDateInput"
+                                >
+                            </div>
+                        </div>
+                    </fieldset>
+
                     <div class="create-more-option">
                         <label class="checkbox-label">
                             <input type="checkbox" id="createMoreCheckbox">

--- a/styles.css
+++ b/styles.css
@@ -1125,14 +1125,50 @@ h1 {
 .modal-form {
     display: flex;
     flex-direction: column;
-    gap: 15px;
+    gap: 20px;
+}
+
+/* Form Sections */
+.form-section {
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
+.form-section-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #888;
+    margin-bottom: 12px;
+    padding: 0;
+}
+
+.form-field {
+    margin-bottom: 12px;
+}
+
+.form-field:last-child {
+    margin-bottom: 0;
+}
+
+.form-row {
+    display: flex;
+    gap: 12px;
+}
+
+.form-row .form-field {
+    flex: 1;
+    margin-bottom: 12px;
 }
 
 .modal-form label {
-    font-weight: 600;
+    font-weight: 500;
     color: #333;
-    margin-bottom: 5px;
+    margin-bottom: 6px;
     display: block;
+    font-size: 14px;
 }
 
 .modal-form input,
@@ -1266,6 +1302,11 @@ h1 {
 
     .user-actions {
         flex-shrink: 0;
+    }
+
+    .form-row {
+        flex-direction: column;
+        gap: 0;
     }
 }
 
@@ -1601,6 +1642,35 @@ h1 {
     color: var(--ios-label);
     font-weight: 400;
     font-size: 15px;
+}
+
+/* iOS Form Sections */
+[data-theme="glass"] .form-section {
+    background: var(--ios-bg-secondary);
+    border-radius: 12px;
+    padding: 16px;
+    border: 1px solid var(--ios-separator);
+}
+
+[data-theme="glass"] .form-section-title {
+    color: var(--ios-label-secondary);
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 16px;
+}
+
+[data-theme="glass"] .form-field {
+    margin-bottom: 16px;
+}
+
+[data-theme="glass"] .form-row {
+    gap: 16px;
+}
+
+[data-theme="glass"] .form-row .form-field {
+    margin-bottom: 16px;
 }
 
 /* iOS Buttons - Filled style */
@@ -2031,12 +2101,19 @@ h1 {
     -webkit-backdrop-filter: blur(var(--ios-blur-thick));
     border: none;
     box-shadow: 0 25px 80px rgba(0, 0, 0, 0.35);
-    border-radius: 14px;
+    border-radius: 20px;
+    padding: 24px;
+    max-width: 520px;
+}
+
+[data-theme="glass"] .modal-form {
+    gap: 16px;
 }
 
 [data-theme="glass"] .modal-header {
     border-bottom: 0.5px solid var(--ios-separator);
-    padding-bottom: 15px;
+    padding-bottom: 16px;
+    margin-bottom: 8px;
 }
 
 [data-theme="glass"] .modal-header h2 {


### PR DESCRIPTION
## Summary
- Redesigns the add/edit todo modal with a more spacious, iOS-inspired layout
- Organizes form fields into logical groups for better usability
- Enhances the Glass theme with bordered sections and improved spacing

## Problem
The existing modal form had all fields in a flat list with minimal organization. Users requested a more spacious design with logically grouped fields, particularly optimized for the Glass theme.

## Solution
Reorganized the form into semantic fieldsets with a two-column layout for related fields:

### Field Groups
1. **Task** - "What needs to be done?" text input and Notes textarea
2. **Organization** - Category and Project selects (side by side)
3. **Planning** - Status, Priority, Context, and Due Date (2x2 grid)

### Visual Improvements
- Section titles styled as uppercase labels
- Two-column layout for related fields (responsive to single column on mobile)
- Glass theme: sections have white backgrounds with subtle borders
- Increased padding and rounded corners in Glass theme modal
- Consistent field spacing within sections

## Changes
- **index.html**: Restructured form using `<fieldset>` elements with `.form-section`, `.form-field`, and `.form-row` classes
- **styles.css**: Added styling for form sections, rows, and fields in both default and Glass themes; added mobile responsive rules

## Test plan
- [ ] Open add todo modal in default theme, verify grouped layout
- [ ] Open in Glass theme, verify sections have white backgrounds with borders
- [ ] Resize browser to mobile width, verify two-column rows stack vertically
- [ ] Edit a todo, verify form layout is consistent
- [ ] Test keyboard navigation through fields

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)