### PR TITLE
feat: Add toggle behavior for project selection (fixes #100)

### DIFF
--- a/app.js
+++ b/app.js
@@ -954,7 +954,16 @@ class TodoApp {
     }
 
     selectProject(projectId) {
-        this.selectedProjectId = projectId
+        // Toggle: clicking a project adds/removes it from the selection
+        if (projectId === null) {
+            // "All Projects" clears the selection
+            this.selectedProjectId = null
+        } else if (this.selectedProjectId === projectId) {
+            // Clicking the same project deselects it
+            this.selectedProjectId = null
+        } else {
+            this.selectedProjectId = projectId
+        }
         this.renderProjects()
         this.renderTodos()
     }


### PR DESCRIPTION
## Summary
Implements toggle behavior for project selection, making it consistent with categories and contexts.

## Problem
As described in #100, categories and contexts support toggle selection (clicking an already-selected item deselects it), but projects did not have this behavior. Clicking a selected project had no effect.

## Solution
Updated the `selectProject()` method to match the toggle pattern used by `selectCategory()` and `selectContext()`:
- Clicking "All Projects" clears the selection
- Clicking an already-selected project deselects it (returns to "All Projects" view)
- Clicking a different project selects it

## Changes
- `app.js`: Updated `selectProject()` to add toggle logic

## Testing
- [x] Clicking a project filters todos to that project
- [x] Clicking the same project again deselects it and shows all todos
- [x] Clicking "All Projects" clears the selection
- [x] Behavior matches categories and contexts

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)