### PR TITLE
feat: Add Scheduled view to GTD sidebar (fixes #102)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1059,6 +1059,10 @@ class TodoApp {
             // Count all non-done items
             return this.todos.filter(t => t.gtd_status !== 'done').length
         }
+        if (status === 'scheduled') {
+            // Count all non-done items with a due date
+            return this.todos.filter(t => t.due_date && t.gtd_status !== 'done').length
+        }
         return this.todos.filter(t => t.gtd_status === status).length
     }
 
@@ -1066,6 +1070,7 @@ class TodoApp {
         const icons = {
             'inbox': '📥',
             'next_action': '»',
+            'scheduled': '📆',
             'waiting_for': '⏳',
             'someday_maybe': '📅',
             'done': '✓',
@@ -1078,6 +1083,7 @@ class TodoApp {
         const statuses = [
             { id: 'inbox', label: 'Inbox' },
             { id: 'next_action', label: 'Next' },
+            { id: 'scheduled', label: 'Scheduled', isVirtual: true },
             { id: 'waiting_for', label: 'Waiting' },
             { id: 'someday_maybe', label: 'Someday' },
             { id: 'done', label: 'Done' },
@@ -1102,8 +1108,8 @@ class TodoApp {
 
             li.addEventListener('click', () => this.selectGtdStatus(status.id))
 
-            // Drop target for assigning GTD status (except 'all')
-            if (status.id !== 'all') {
+            // Drop target for assigning GTD status (except 'all' and 'scheduled')
+            if (status.id !== 'all' && !status.isVirtual) {
                 li.addEventListener('dragover', (e) => {
                     e.preventDefault()
                     e.dataTransfer.dropEffect = 'move'
@@ -1686,7 +1692,14 @@ class TodoApp {
         }
 
         // Filter by GTD status
-        if (this.selectedGtdStatus === 'done') {
+        if (this.selectedGtdStatus === 'scheduled') {
+            // Show all non-done items with a due date, sorted by date
+            filtered = filtered.filter(t => t.due_date && t.gtd_status !== 'done')
+            // Sort by due date (earliest first)
+            return filtered.slice().sort((a, b) => {
+                return a.due_date.localeCompare(b.due_date)
+            })
+        } else if (this.selectedGtdStatus === 'done') {
             // Show only done items when Done tab is selected
             filtered = filtered.filter(t => t.gtd_status === 'done')
         } else if (this.selectedGtdStatus !== 'all') {

--- a/styles.css
+++ b/styles.css
@@ -1375,6 +1375,7 @@ h1 {
 
 .gtd-item.inbox .gtd-icon { color: #1976d2; }
 .gtd-item.next_action .gtd-icon { color: #388e3c; }
+.gtd-item.scheduled .gtd-icon { color: #e91e63; }
 .gtd-item.waiting_for .gtd-icon { color: #f57c00; }
 .gtd-item.someday_maybe .gtd-icon { color: #7b1fa2; }
 .gtd-item.done .gtd-icon { color: #2e7d32; }


### PR DESCRIPTION
## Summary
Adds a new "Scheduled" view to the GTD sidebar that displays all todos with due dates.

## Problem
As described in #102, there was no way to see all scheduled todos (those with due dates) in one view. Users had to look through different GTD statuses to find items with dates.

## Solution
Added a "Scheduled" virtual view that:
- Appears between "Next" and "Waiting" in the GTD sidebar
- Shows all non-completed todos that have a due date set
- Sorts todos by due date (earliest first)
- Displays the count of scheduled items

### Design Decisions
- **Virtual view**: "Scheduled" is not a real GTD status, so you cannot drag items to assign this status
- **Cross-status**: Shows items from all GTD statuses (inbox, next, waiting, someday) as long as they have a due date
- **Excludes done**: Completed items are not shown in the scheduled view
- **Date sorting**: Items are sorted chronologically by due date, not by priority
- **Icon**: Uses 📆 (calendar) with pink/magenta color (#e91e63) to stand out

## Changes
- `app.js`: 
  - Added "scheduled" to GTD statuses list (with `isVirtual: true` flag)
  - Added scheduled icon to `getGtdIcon()`
  - Updated `getGtdCount()` to count items with due dates
  - Updated `getFilteredTodos()` to filter and sort by due date
  - Updated drop target logic to skip virtual statuses
- `styles.css`:
  - Added `.gtd-item.scheduled .gtd-icon` color rule

## Testing
- [x] Scheduled view appears between Next and Waiting
- [x] Shows correct count of todos with due dates
- [x] Clicking Scheduled shows only items with due dates
- [x] Items are sorted by due date (earliest first)
- [x] Cannot drag-drop items onto Scheduled (virtual status)
- [x] Completed items excluded from scheduled view

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)