### PR TITLE
feat: Update edit/add form to two-column layout (fixes #104)

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,86 +200,85 @@
                     <button id="closeModal" class="modal-close" aria-label="Close modal">&times;</button>
                 </div>
                 <form id="addTodoForm" class="modal-form">
-                    <!-- Task Section -->
-                    <fieldset class="form-section">
-                        <legend class="form-section-title">Task</legend>
-                        <div class="form-field">
-                            <label for="modalTodoInput">What needs to be done?</label>
-                            <input
-                                type="text"
-                                id="modalTodoInput"
-                                placeholder="Enter todo description..."
-                                autocomplete="off"
-                                required
-                            >
+                    <div class="form-columns">
+                        <!-- Left Column: Task -->
+                        <div class="form-column">
+                            <fieldset class="form-section">
+                                <legend class="form-section-title">Task</legend>
+                                <div class="form-field">
+                                    <label for="modalTodoInput">What needs to be done?</label>
+                                    <input
+                                        type="text"
+                                        id="modalTodoInput"
+                                        placeholder="Enter todo description..."
+                                        autocomplete="off"
+                                        required
+                                    >
+                                </div>
+                                <div class="form-field">
+                                    <label for="modalCommentInput">Notes</label>
+                                    <textarea
+                                        id="modalCommentInput"
+                                        placeholder="Add additional notes or details..."
+                                        maxlength="1024"
+                                        rows="6"
+                                    ></textarea>
+                                </div>
+                            </fieldset>
                         </div>
-                        <div class="form-field">
-                            <label for="modalCommentInput">Notes</label>
-                            <textarea
-                                id="modalCommentInput"
-                                placeholder="Add additional notes or details..."
-                                maxlength="1024"
-                                rows="3"
-                            ></textarea>
-                        </div>
-                    </fieldset>
 
-                    <!-- Organization Section -->
-                    <fieldset class="form-section">
-                        <legend class="form-section-title">Organization</legend>
-                        <div class="form-row">
-                            <div class="form-field">
-                                <label for="modalCategorySelect">Category</label>
-                                <select id="modalCategorySelect">
-                                    <option value="">No Category</option>
-                                </select>
-                            </div>
-                            <div class="form-field">
-                                <label for="modalProjectSelect">Project</label>
-                                <select id="modalProjectSelect">
-                                    <option value="">No Project</option>
-                                </select>
-                            </div>
-                        </div>
-                    </fieldset>
+                        <!-- Right Column: Organization & Planning -->
+                        <div class="form-column">
+                            <fieldset class="form-section">
+                                <legend class="form-section-title">Organization</legend>
+                                <div class="form-field">
+                                    <label for="modalCategorySelect">Category</label>
+                                    <select id="modalCategorySelect">
+                                        <option value="">No Category</option>
+                                    </select>
+                                </div>
+                                <div class="form-field">
+                                    <label for="modalProjectSelect">Project</label>
+                                    <select id="modalProjectSelect">
+                                        <option value="">No Project</option>
+                                    </select>
+                                </div>
+                            </fieldset>
 
-                    <!-- Planning Section -->
-                    <fieldset class="form-section">
-                        <legend class="form-section-title">Planning</legend>
-                        <div class="form-row">
-                            <div class="form-field">
-                                <label for="modalGtdStatusSelect">Status</label>
-                                <select id="modalGtdStatusSelect" aria-label="GTD Status">
-                                    <option value="inbox">Inbox</option>
-                                    <option value="next_action">Next Action</option>
-                                    <option value="waiting_for">Waiting For</option>
-                                    <option value="someday_maybe">Someday/Maybe</option>
-                                    <option value="done">Done</option>
-                                </select>
-                            </div>
-                            <div class="form-field">
-                                <label for="modalPrioritySelect">Priority</label>
-                                <select id="modalPrioritySelect" aria-label="Priority">
-                                    <option value="">No Priority</option>
-                                </select>
-                            </div>
+                            <fieldset class="form-section">
+                                <legend class="form-section-title">Planning</legend>
+                                <div class="form-field">
+                                    <label for="modalGtdStatusSelect">Status</label>
+                                    <select id="modalGtdStatusSelect" aria-label="GTD Status">
+                                        <option value="inbox">Inbox</option>
+                                        <option value="next_action">Next Action</option>
+                                        <option value="waiting_for">Waiting For</option>
+                                        <option value="someday_maybe">Someday/Maybe</option>
+                                        <option value="done">Done</option>
+                                    </select>
+                                </div>
+                                <div class="form-field">
+                                    <label for="modalPrioritySelect">Priority</label>
+                                    <select id="modalPrioritySelect" aria-label="Priority">
+                                        <option value="">No Priority</option>
+                                    </select>
+                                </div>
+                                <div class="form-field">
+                                    <label for="modalContextSelect">Context</label>
+                                    <select id="modalContextSelect" aria-label="Context">
+                                        <option value="">No Context</option>
+                                    </select>
+                                </div>
+                                <div class="form-field">
+                                    <label for="modalDueDateInput">Due Date</label>
+                                    <input
+                                        type="date"
+                                        id="modalDueDateInput"
+                                    >
+                                </div>
+                            </fieldset>
                         </div>
-                        <div class="form-row">
-                            <div class="form-field">
-                                <label for="modalContextSelect">Context</label>
-                                <select id="modalContextSelect" aria-label="Context">
-                                    <option value="">No Context</option>
-                                </select>
-                            </div>
-                            <div class="form-field">
-                                <label for="modalDueDateInput">Due Date</label>
-                                <input
-                                    type="date"
-                                    id="modalDueDateInput"
-                                >
-                            </div>
-                        </div>
-                    </fieldset>
+                    </div>
 
                     <div class="create-more-option">
                         <label class="checkbox-label">

--- a/styles.css
+++ b/styles.css
@@ -1082,7 +1082,7 @@ h1 {
     background: white;
     border-radius: 15px;
     padding: 30px;
-    max-width: 600px;
+    max-width: 720px;
     width: 90%;
     max-height: 90vh;
     overflow-y: auto;
@@ -1126,6 +1126,19 @@ h1 {
     display: flex;
     flex-direction: column;
     gap: 20px;
+}
+
+/* Two-column form layout */
+.form-columns {
+    display: flex;
+    gap: 24px;
+}
+
+.form-column {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 }
 
 /* Form Sections */
@@ -1307,6 +1320,10 @@ h1 {
     .form-row {
         flex-direction: column;
         gap: 0;
+    }
+
+    .form-columns {
+        flex-direction: column;
     }
 }
 
@@ -2104,7 +2121,7 @@ h1 {
     box-shadow: 0 25px 80px rgba(0, 0, 0, 0.35);
     border-radius: 20px;
     padding: 24px;
-    max-width: 520px;
+    max-width: 720px;
 }
 
 [data-theme="glass"] .modal-form {


### PR DESCRIPTION
## Summary
Updates the add/edit todo modal form to use a two-column layout for better use of horizontal space.

## Problem
As described in #104, the form layout needed to be updated to two columns for a more efficient use of space on wider screens.

## Solution
Implemented a two-column layout:
- **Left column**: Task section with the todo description input and an expanded notes textarea
- **Right column**: Organization section (Category, Project) and Planning section (Status, Priority, Context, Due Date)

### Layout Details
- Columns display side-by-side on desktop (>768px)
- Columns stack vertically on mobile (<=768px) for responsive design
- Modal width increased from 600px to 720px to accommodate the new layout
- Notes textarea expanded to 6 rows to fill the left column height

## Changes
- `index.html`: 
  - Added `.form-columns` wrapper around form sections
  - Split sections into two `.form-column` containers
  - Simplified right column fields to single-column layout
  - Increased textarea rows from 3 to 6
- `styles.css`:
  - Added `.form-columns` flexbox container with 24px gap
  - Added `.form-column` with flex: 1 and column direction
  - Increased `.modal` max-width to 720px
  - Increased Glass theme modal max-width to 720px
  - Added responsive rule for `.form-columns` to stack on mobile

## Testing
- [x] Two columns display correctly on desktop
- [x] Columns stack on mobile viewport
- [x] Form fields remain functional
- [x] Works with both default and Glass themes

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)