### PR TITLE
feat: Add section headers to Scheduled view (fixes #110)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -832,6 +832,49 @@ h1 {
     min-height: 360px;
 }
 
+/* Scheduled view section headers */
+.scheduled-section-header {
+    background: linear-gradient(135deg, var(--primary-start) 0%, var(--primary-end) 100%);
+    padding: 10px 15px;
+    margin-bottom: 5px;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 14px;
+    color: white;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.scheduled-section-header.overdue {
+    background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+}
+
+.scheduled-section-header.today {
+    background: linear-gradient(135deg, #f39c12 0%, #d68910 100%);
+}
+
+.scheduled-section-header.tomorrow {
+    background: linear-gradient(135deg, #3498db 0%, #2980b9 100%);
+}
+
+.scheduled-section-header.this-week {
+    background: linear-gradient(135deg, #9b59b6 0%, #8e44ad 100%);
+}
+
+.scheduled-section-header.next-week {
+    background: linear-gradient(135deg, #1abc9c 0%, #16a085 100%);
+}
+
+.scheduled-section-header.later {
+    background: linear-gradient(135deg, #95a5a6 0%, #7f8c8d 100%);
+}
+
+.section-header-text {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .todo-item {
     background: #f8f9fa;
     padding: 15px;
@@ -1967,6 +2010,50 @@ h1 {
     border-radius: 12px;
     overflow: hidden;
     border: 1px solid var(--ios-separator);
+}
+
+/* iOS Scheduled Section Headers */
+[data-theme="glass"] .scheduled-section-header {
+    background: var(--ios-gray5);
+    color: var(--ios-label-secondary);
+    border-radius: 0;
+    margin-bottom: 0;
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 0.5px solid var(--ios-separator);
+}
+
+[data-theme="glass"] .scheduled-section-header.overdue {
+    background: rgba(255, 59, 48, 0.15);
+    color: var(--ios-red);
+}
+
+[data-theme="glass"] .scheduled-section-header.today {
+    background: rgba(255, 149, 0, 0.15);
+    color: var(--ios-orange);
+}
+
+[data-theme="glass"] .scheduled-section-header.tomorrow {
+    background: rgba(0, 122, 255, 0.15);
+    color: var(--ios-blue);
+}
+
+[data-theme="glass"] .scheduled-section-header.this-week {
+    background: rgba(175, 82, 222, 0.15);
+    color: #af52de;
+}
+
+[data-theme="glass"] .scheduled-section-header.next-week {
+    background: rgba(52, 199, 89, 0.15);
+    color: #34c759;
+}
+
+[data-theme="glass"] .scheduled-section-header.later {
+    background: var(--ios-gray5);
+    color: var(--ios-label-secondary);
 }
 
 [data-theme="glass"] .todo-item {


### PR DESCRIPTION
## Summary
Enhance the Scheduled view with visual section headers that group todos by date proximity.

## Problem
The Scheduled view showed all todos with due dates in a flat list without visual grouping, making it hard to distinguish urgent items from future ones (issue #110).

## Solution
Added color-coded section headers that group todos into:
- **Overdue** (red) - Past due items
- **Today** (orange) - Due today
- **Tomorrow** (blue) - Due tomorrow  
- **This Week** (purple) - Due within this week
- **Next Week** (green) - Due next week
- **Later** (gray) - Due beyond next week

## Changes
- Added `getDateGroup()` method to categorize todos by relative date
- Added `getDateGroupLabel()` method for human-readable labels
- Updated `renderTodos()` to insert section headers when viewing Scheduled
- Added CSS styling for section headers with gradient backgrounds
- Added Glass theme styling for iOS-consistent appearance

## Visual Preview
```
┌─────────────────────────────────────┐
│ OVERDUE                             │ (red)
├─────────────────────────────────────┤
│ [ ] Pay electric bill               │
├─────────────────────────────────────┤
│ TODAY                               │ (orange)
├─────────────────────────────────────┤
│ [ ] Meeting with team               │
│ [ ] Submit report                   │
├─────────────────────────────────────┤
│ TOMORROW                            │ (blue)
├─────────────────────────────────────┤
│ [ ] Doctor appointment              │
└─────────────────────────────────────┘
```

## Testing
- [ ] Navigate to Scheduled view
- [ ] Verify section headers appear between date groups
- [ ] Verify correct color coding for each group
- [ ] Test with Glass theme
- [ ] Verify todos are still properly sorted by date

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)