### PR TITLE
feat: Add 'scheduled' as a proper GTD status (fixes #111)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1697,10 +1697,13 @@ class TodoApp {
 
         // Filter by GTD status
         if (this.selectedGtdStatus === 'scheduled') {
-            // Show all non-done items with a due date, sorted by date
-            filtered = filtered.filter(t => t.due_date && t.gtd_status !== 'done')
-            // Sort by due date (earliest first)
+            // Show items with 'scheduled' GTD status, sorted by due date
+            filtered = filtered.filter(t => t.gtd_status === 'scheduled')
+            // Sort by due date (earliest first), items without dates go last
             return filtered.slice().sort((a, b) => {
+                if (!a.due_date && !b.due_date) return 0
+                if (!a.due_date) return 1
+                if (!b.due_date) return -1
                 return a.due_date.localeCompare(b.due_date)
             })
         } else if (this.selectedGtdStatus === 'done') {
@@ -1744,6 +1747,7 @@ class TodoApp {
         const labels = {
             'inbox': 'Inbox',
             'next_action': 'Next',
+            'scheduled': 'Scheduled',
             'waiting_for': 'Waiting',
             'someday_maybe': 'Someday',
             'done': 'Done'

--- a/index.html
+++ b/index.html
@@ -254,6 +254,7 @@
                                     <select id="modalGtdStatusSelect" aria-label="GTD Status">
                                         <option value="inbox">Inbox</option>
                                         <option value="next_action">Next Action</option>
+                                        <option value="scheduled">Scheduled</option>
                                         <option value="waiting_for">Waiting For</option>
                                         <option value="someday_maybe">Someday/Maybe</option>
                                         <option value="done">Done</option>

--- a/styles.css
+++ b/styles.css
@@ -1613,6 +1613,11 @@ h1 {
     color: #388e3c;
 }
 
+.todo-gtd-badge.scheduled {
+    background: #fce4ec;
+    color: #c2185b;
+}
+
 .todo-gtd-badge.waiting_for {
     background: #fff3e0;
     color: #f57c00;
@@ -2495,6 +2500,11 @@ h1 {
 [data-theme="glass"] .todo-gtd-badge.next_action {
     background: rgba(52, 199, 89, 0.15);
     color: #34c759;
+}
+
+[data-theme="glass"] .todo-gtd-badge.scheduled {
+    background: rgba(255, 45, 85, 0.15);
+    color: #ff2d55;
 }
 
 [data-theme="glass"] .todo-gtd-badge.waiting_for {


### PR DESCRIPTION
## Summary
- Adds 'scheduled' as a proper GTD status option in the todo creation/edit modal
- Updates Scheduled sidebar view to filter by `gtd_status === 'scheduled'` instead of presence of due date
- Adds CSS styling for the scheduled badge (pink theme for default, iOS pink for Glass theme)

This ensures scheduled todos don't appear in Inbox, resolving the overlap issue described in #111.

## Test plan
- [ ] Open the Add Todo modal and verify 'Scheduled' appears in the Status dropdown
- [ ] Create a todo with 'Scheduled' status and verify it appears in Scheduled view
- [ ] Verify the todo does NOT appear in Inbox
- [ ] Verify the scheduled badge displays with pink styling
- [ ] Test with Glass theme to ensure badge styling is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)