### PR TITLE
feat: Sync scheduled status with due date

### DIFF
--- a/app.js
+++ b/app.js
@@ -296,6 +296,21 @@ class TodoApp {
             }
         })
 
+        // Sync due date and scheduled status
+        this.modalDueDateInput.addEventListener('change', () => {
+            if (this.modalDueDateInput.value) {
+                // Auto-set scheduled status when due date is filled
+                this.modalGtdStatusSelect.value = 'scheduled'
+            }
+        })
+
+        this.modalGtdStatusSelect.addEventListener('change', () => {
+            if (this.modalGtdStatusSelect.value === 'scheduled' && !this.modalDueDateInput.value) {
+                // Focus on due date input when scheduled is selected without a date
+                this.modalDueDateInput.focus()
+            }
+        })
+
         // Add category
         this.addCategoryBtn.addEventListener('click', () => this.addCategory())
         this.newCategoryInput.addEventListener('keypress', (e) => {
@@ -1449,15 +1464,23 @@ class TodoApp {
         const text = this.modalTodoInput.value.trim()
         if (!text) return
 
+        const gtdStatus = this.modalGtdStatusSelect.value || 'inbox'
+        const dueDate = this.modalDueDateInput.value || null
+
+        // Validate: scheduled status requires a due date
+        if (gtdStatus === 'scheduled' && !dueDate) {
+            alert('A due date is required for scheduled todos')
+            this.modalDueDateInput.focus()
+            return
+        }
+
         this.modalAddBtn.disabled = true
         this.modalAddBtn.textContent = 'Adding...'
 
         const categoryId = this.modalCategorySelect.value || null
         const projectId = this.modalProjectSelect.value || null
         const priorityId = this.modalPrioritySelect.value || null
-        const gtdStatus = this.modalGtdStatusSelect.value || 'inbox'
         const contextId = this.modalContextSelect.value || null
-        const dueDate = this.modalDueDateInput.value || null
         const comment = this.modalCommentInput.value.trim() || null
 
         // Encrypt todo text before storing
@@ -1515,15 +1538,23 @@ class TodoApp {
         const text = this.modalTodoInput.value.trim()
         if (!text || !this.editingTodoId) return
 
+        const gtdStatus = this.modalGtdStatusSelect.value || 'inbox'
+        const dueDate = this.modalDueDateInput.value || null
+
+        // Validate: scheduled status requires a due date
+        if (gtdStatus === 'scheduled' && !dueDate) {
+            alert('A due date is required for scheduled todos')
+            this.modalDueDateInput.focus()
+            return
+        }
+
         this.modalAddBtn.disabled = true
         this.modalAddBtn.textContent = 'Saving...'
 
         const categoryId = this.modalCategorySelect.value || null
         const projectId = this.modalProjectSelect.value || null
         const priorityId = this.modalPrioritySelect.value || null
-        const gtdStatus = this.modalGtdStatusSelect.value || 'inbox'
         const contextId = this.modalContextSelect.value || null
-        const dueDate = this.modalDueDateInput.value || null
         const comment = this.modalCommentInput.value.trim() || null
 
         // Encrypt todo text before storing

--- a/migrations/009_set_scheduled_status_for_todos_with_due_date.sql
+++ b/migrations/009_set_scheduled_status_for_todos_with_due_date.sql
@@ -1,0 +1,9 @@
+-- Update existing todos with due dates to have 'scheduled' GTD status
+-- This ensures consistency with the new behavior where due date requires scheduled status
+
+UPDATE todos
+SET gtd_status = 'scheduled'
+WHERE due_date IS NOT NULL
+  AND gtd_status != 'done';
+
+-- Note: We exclude 'done' status to preserve completed todos


### PR DESCRIPTION
## Summary
- Auto-sets 'scheduled' GTD status when a due date is filled in the modal
- Requires a due date when 'scheduled' status is selected (shows alert if missing)
- Adds database migration to update existing todos with due dates to 'scheduled' status

This ensures scheduled todos always have a due date and todos with due dates are always in the Scheduled view.

## Changes
- Added event listeners for syncing due date and scheduled status in real-time
- Added validation in `addTodo()` and `updateTodo()` to require due date for scheduled status
- Created migration `009_set_scheduled_status_for_todos_with_due_date.sql`

## Database Migration Required
After merging, run this SQL in Supabase to update existing records:
```sql
UPDATE todos
SET gtd_status = 'scheduled'
WHERE due_date IS NOT NULL
  AND gtd_status != 'done';
```

## Test plan
- [ ] Set a due date and verify status auto-changes to 'scheduled'
- [ ] Select 'scheduled' status without due date and verify focus moves to date input
- [ ] Try to save with 'scheduled' status and no due date - should show alert
- [ ] Verify existing todos with due dates show in Scheduled view after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)