### PR TITLE
feat: Add Project View when clicking All Projects (fixes #116)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -738,6 +738,48 @@ h1 {
     cursor: not-allowed;
 }
 
+/* Project View Cards */
+.project-card {
+    background: #f8f9fa;
+    padding: 18px 20px;
+    margin-bottom: 10px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    border-left: 4px solid transparent;
+}
+
+.project-card:hover {
+    background: #e9ecef;
+    transform: translateX(5px);
+}
+
+.project-card-color {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.project-card-name {
+    flex: 1;
+    font-size: 16px;
+    font-weight: 500;
+    color: #333;
+}
+
+.project-card-count {
+    font-size: 14px;
+    color: #666;
+    background: #e0e0e0;
+    padding: 4px 12px;
+    border-radius: 12px;
+    font-weight: 500;
+}
+
 .content {
     flex: 1;
     min-width: 0;
@@ -1974,6 +2016,32 @@ h1 {
 [data-theme="glass"] .add-project-form {
     border-top: none;
     padding: 20px 5px 0 5px; /* Horizontal padding for input focus outline */
+}
+
+/* iOS Project View Cards */
+[data-theme="glass"] .project-card {
+    background: var(--ios-bg-secondary);
+    border: 1px solid var(--ios-separator);
+    border-left: none;
+    border-radius: 12px;
+    padding: 16px 18px;
+    margin-bottom: 8px;
+}
+
+[data-theme="glass"] .project-card:hover {
+    background: var(--ios-gray6);
+    transform: none;
+}
+
+[data-theme="glass"] .project-card-name {
+    color: var(--ios-label);
+    font-size: 17px;
+}
+
+[data-theme="glass"] .project-card-count {
+    background: var(--ios-gray5);
+    color: var(--ios-label-secondary);
+    font-size: 13px;
 }
 
 [data-theme="glass"] .add-project-input {


### PR DESCRIPTION
## Summary
Adds a new Project View that displays when clicking "All Projects" in the sidebar, showing a list of projects with their item counts instead of all todos.

## Problem
Previously, clicking "All Projects" would show all todos across all projects, which wasn't useful for getting an overview of projects.

## Solution
- Added a `showProjectsView` state flag
- When "All Projects" is clicked, display a list of project cards
- Each card shows project name, color, and active item count
- Clicking a project card shows its todos (existing behavior)

## Changes
- `app.js`: Added state, helpers, and `renderProjectsView()` method
- `styles.css`: Added `.project-card` styling for default and Glass themes

## Testing
- [ ] Click "All Projects" - should show project list view
- [ ] Verify each project shows name and item count
- [ ] Click a project card - should show todos for that project
- [ ] Test with Glass theme - cards should have iOS styling

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)