### PR TITLE
fix: Switch GTD filter to 'all' when selecting project from Project View

### DIFF
--- a/app.js
+++ b/app.js
@@ -982,6 +982,9 @@ class TodoApp {
             // Clicking a specific project shows its todos
             this.selectedProjectId = projectId
             this.showProjectsView = false
+            // Switch GTD filter to 'all' to show all items in this project
+            this.selectedGtdStatus = 'all'
+            this.renderGtdList()
         }
         this.renderProjects()
         this.renderTodos()


### PR DESCRIPTION
## Summary
When clicking a project card in the Project View, automatically switches the GTD status filter to "All" so users see all items in that project.

## Problem
Previously, when selecting a project from the Project View, the GTD filter would remain on whatever status was previously selected (e.g., Inbox), potentially showing no items even though the project has todos.

## Solution
Added two lines to `selectProject()`:
- Set `selectedGtdStatus` to `'all'`
- Call `renderGtdList()` to update the sidebar highlight

## Test plan
- [ ] Go to Project View (click "All Projects")
- [ ] Click on a project with items
- [ ] Verify the GTD sidebar shows "All" as active
- [ ] Verify all items for that project are displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)