### PR TITLE
feat: Add drag handle indicator for todo items (fixes #119)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1912,18 +1912,7 @@ class TodoApp {
                 // Derive completed state from gtd_status (unified status)
                 const isCompleted = todo.gtd_status === 'done'
                 li.className = `todo-item ${isCompleted ? 'completed' : ''}`
-                li.draggable = true
                 li.dataset.todoId = todo.id
-
-                // Drag event handlers
-                li.addEventListener('dragstart', (e) => {
-                    e.dataTransfer.setData('text/plain', todo.id)
-                    e.dataTransfer.effectAllowed = 'move'
-                    li.classList.add('dragging')
-                })
-                li.addEventListener('dragend', () => {
-                    li.classList.remove('dragging')
-                })
 
                 const category = todo.category_id ? (this.getCategoryById(todo.category_id) ?? null) : null
                 const categoryBadge = category
@@ -1954,6 +1943,7 @@ class TodoApp {
                 }
 
                 li.innerHTML = `
+                    <span class="drag-handle" draggable="true">⋮⋮</span>
                     <input
                         type="checkbox"
                         class="todo-checkbox"
@@ -1972,6 +1962,17 @@ class TodoApp {
                     <button class="edit-btn" data-id="${todo.id}">Edit</button>
                     <button class="delete-btn" data-id="${todo.id}">Delete</button>
                 `
+
+                // Drag handle events
+                const dragHandle = li.querySelector('.drag-handle')
+                dragHandle.addEventListener('dragstart', (e) => {
+                    e.dataTransfer.setData('text/plain', todo.id)
+                    e.dataTransfer.effectAllowed = 'move'
+                    li.classList.add('dragging')
+                })
+                dragHandle.addEventListener('dragend', () => {
+                    li.classList.remove('dragging')
+                })
 
                 const checkbox = li.querySelector('.todo-checkbox')
                 checkbox.addEventListener('change', () => this.toggleTodo(todo.id))

--- a/styles.css
+++ b/styles.css
@@ -955,9 +955,6 @@ h1 {
     cursor: grabbing;
 }
 
-.todo-item[draggable="true"] {
-    cursor: grab;
-}
 
 /* Drop target styles */
 .category-item.drag-over,
@@ -968,6 +965,30 @@ h1 {
     color: white !important;
     transform: scale(1.02);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.drag-handle {
+    cursor: grab;
+    color: #999;
+    font-size: 14px;
+    padding: 0 4px;
+    user-select: none;
+    opacity: 0.5;
+    transition: opacity 0.2s, color 0.2s;
+}
+
+.drag-handle:hover {
+    opacity: 1;
+    color: #666;
+}
+
+.drag-handle:active {
+    cursor: grabbing;
+}
+
+.todo-item.dragging .drag-handle {
+    opacity: 1;
+    color: var(--accent-color);
 }
 
 .todo-checkbox {
@@ -2152,6 +2173,18 @@ h1 {
 
 [data-theme="glass"] .todo-item.completed {
     opacity: 0.5;
+}
+
+[data-theme="glass"] .drag-handle {
+    color: var(--ios-label-tertiary);
+}
+
+[data-theme="glass"] .drag-handle:hover {
+    color: var(--ios-label-secondary);
+}
+
+[data-theme="glass"] .todo-item.dragging .drag-handle {
+    color: var(--ios-blue);
 }
 
 [data-theme="glass"] .todo-text {


### PR DESCRIPTION
## Summary
- Adds a visual drag handle (⋮⋮) indicator before the checkbox on todo items
- Restricts drag-and-drop functionality to only work when dragging from the handle
- Improves UX by making it clear where to drag and preventing accidental drags

## Changes
- Added drag handle element with `draggable="true"` attribute
- Moved dragstart/dragend events from the todo item to the handle only
- Added CSS styling for the handle with hover and active states
- Added Glass theme specific styling for consistency

## Test plan
- [ ] Verify drag handle appears before checkbox on all todo items
- [ ] Verify dragging only works when initiated from the handle
- [ ] Verify handle has grab cursor and highlights on hover
- [ ] Verify todo item shows dragging state when being dragged
- [ ] Test in Glass theme for proper styling

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)