### PR TITLE
fix: Improve drag handle visibility and size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -969,17 +969,19 @@ h1 {
 
 .drag-handle {
     cursor: grab;
-    color: #999;
-    font-size: 14px;
-    padding: 0 4px;
+    color: #888;
+    font-size: 18px;
+    padding: 2px 6px;
     user-select: none;
-    opacity: 0.5;
-    transition: opacity 0.2s, color 0.2s;
+    opacity: 0.6;
+    transition: opacity 0.2s, color 0.2s, transform 0.2s, background-color 0.2s;
+    border-radius: 4px;
 }
 
 .drag-handle:hover {
     opacity: 1;
-    color: #666;
+    color: #555;
+    background-color: rgba(0, 0, 0, 0.05);
 }
 
 .drag-handle:active {
@@ -988,7 +990,9 @@ h1 {
 
 .todo-item.dragging .drag-handle {
     opacity: 1;
-    color: var(--accent-color);
+    color: white;
+    background-color: var(--accent-color);
+    transform: scale(1.15);
 }
 
 .todo-checkbox {
@@ -2181,10 +2185,13 @@ h1 {
 
 [data-theme="glass"] .drag-handle:hover {
     color: var(--ios-label-secondary);
+    background-color: var(--ios-gray5);
 }
 
 [data-theme="glass"] .todo-item.dragging .drag-handle {
-    color: var(--ios-blue);
+    color: white;
+    background-color: var(--ios-blue);
+    transform: scale(1.15);
 }
 
 [data-theme="glass"] .todo-text {


### PR DESCRIPTION
## Summary
- Makes drag handle indicators larger and more visible
- Adds prominent visual feedback when actively dragging

## Changes
- Increased font size from 14px to 18px
- Increased base opacity from 0.5 to 0.6
- Added background color on hover for clearer feedback
- When dragging: white text on accent-colored background with 1.15x scale
- Updated Glass theme styles for consistency

## Test plan
- [ ] Verify drag handle is more visible at default state
- [ ] Verify hover shows subtle background highlight
- [ ] Verify dragging shows prominent accent color background
- [ ] Test in Glass theme for proper iOS-style appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)