### PR TITLE
fix: Remove Edit button from todo items (fixes #122)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1959,7 +1959,6 @@ class TodoApp {
                     ${contextBadge}
                     ${dateBadge}
                     ${categoryBadge}
-                    <button class="edit-btn" data-id="${todo.id}">Edit</button>
                     <button class="delete-btn" data-id="${todo.id}">Delete</button>
                 `
 
@@ -1980,9 +1979,6 @@ class TodoApp {
                 // Click on todo text opens edit modal
                 const todoText = li.querySelector('.todo-text')
                 todoText.addEventListener('click', () => this.openEditModal(todo.id))
-
-                const editBtn = li.querySelector('.edit-btn')
-                editBtn.addEventListener('click', () => this.openEditModal(todo.id))
 
                 const deleteBtn = li.querySelector('.delete-btn')
                 deleteBtn.addEventListener('click', () => this.deleteTodo(todo.id))

--- a/styles.css
+++ b/styles.css
@@ -1069,21 +1069,6 @@ h1 {
     white-space: nowrap;
 }
 
-.edit-btn {
-    background: var(--accent-color);
-    color: white;
-    border: none;
-    padding: 8px 15px;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: 14px;
-    transition: background 0.3s;
-}
-
-.edit-btn:hover {
-    background: var(--accent-hover);
-}
-
 .delete-btn {
     background: #e74c3c;
     color: white;
@@ -2216,19 +2201,6 @@ h1 {
     width: 22px;
     height: 22px;
     accent-color: var(--ios-blue);
-}
-
-[data-theme="glass"] .edit-btn {
-    background: var(--ios-blue);
-    border: none;
-    border-radius: 8px;
-    font-size: 13px;
-    padding: 6px 12px;
-    font-weight: 500;
-}
-
-[data-theme="glass"] .edit-btn:hover {
-    background: var(--ios-blue-hover);
 }
 
 [data-theme="glass"] .delete-btn {


### PR DESCRIPTION
## Summary
Remove the Edit button from todo item lists to simplify the UI.

## Problem
As described in #122, the Edit button on todo items is redundant since users can click directly on the todo text to open the edit modal.

## Solution
Remove the Edit button while keeping the ability to edit todos by clicking on the todo text.

## Changes
- Remove Edit button HTML from todo item template in `app.js`
- Remove Edit button event listener in `app.js`
- Remove Edit button CSS styles (default and glass theme) in `styles.css`

## Testing
- [x] Users can still edit todos by clicking on the todo text
- [x] Delete button remains functional
- [x] No visual regressions

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)