### PR TITLE
fix: Correct CSS theme selectors syntax

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -35,9 +35,7 @@
 }
 
 /* Glass Theme - iOS Style (Light) */
-[data-theme="glass"],
-[data-theme="dark"],
-[data-theme="tint"] {
+[data-theme="glass"] {
     /* iOS System Background Colors */
     --ios-bg-primary: #f2f2f7;
     --ios-bg-secondary: #ffffff;
@@ -1779,8 +1777,8 @@ h1 {
    ======================================== */
 
 /* iOS Background - Subtle light gradient */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] body,
+[data-theme="dark"] body,
 [data-theme="tint"] body {
     background: var(--ios-bg-grouped);
     background-image: linear-gradient(180deg, #ffffff 0%, var(--ios-gray6) 100%);
@@ -1788,8 +1786,8 @@ h1 {
 }
 
 /* iOS Container - Thick material */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .container,
+[data-theme="dark"] .container,
 [data-theme="tint"] .container {
     background: var(--ios-material-thick);
     backdrop-filter: blur(var(--ios-blur-thick));
@@ -1801,8 +1799,8 @@ h1 {
 }
 
 /* iOS Typography */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] h1,
+[data-theme="dark"] h1,
 [data-theme="tint"] h1 {
     color: var(--ios-label);
     font-weight: 700;
@@ -1810,28 +1808,28 @@ h1 {
     letter-spacing: -0.5px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .app-header,
+[data-theme="dark"] .app-header,
 [data-theme="tint"] .app-header {
     gap: 10px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .app-icon,
+[data-theme="dark"] .app-icon,
 [data-theme="tint"] .app-icon {
     width: 32px;
     height: 32px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .app-title,
+[data-theme="dark"] .app-title,
 [data-theme="tint"] .app-title {
     font-weight: 600;
     letter-spacing: -0.3px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] h2,
+[data-theme="dark"] h2,
 [data-theme="tint"] h2 {
     color: var(--ios-label-secondary);
     font-weight: 600;
@@ -1841,16 +1839,16 @@ h1 {
 }
 
 /* iOS Segmented Control (Auth tabs) */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .auth-tabs,
+[data-theme="dark"] .auth-tabs,
 [data-theme="tint"] .auth-tabs {
     background: var(--ios-gray5);
     border-radius: 9px;
     padding: 2px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .auth-tab,
+[data-theme="dark"] .auth-tab,
 [data-theme="tint"] .auth-tab {
     background: transparent;
     border: none;
@@ -1861,14 +1859,14 @@ h1 {
     transition: all 0.2s ease;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .auth-tab:hover,
+[data-theme="dark"] .auth-tab:hover,
 [data-theme="tint"] .auth-tab:hover {
     background: rgba(0, 0, 0, 0.03);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .auth-tab.active,
+[data-theme="dark"] .auth-tab.active,
 [data-theme="tint"] .auth-tab.active {
     background: var(--ios-bg-secondary);
     color: var(--ios-label);
@@ -1877,20 +1875,20 @@ h1 {
 }
 
 /* iOS Form Inputs */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-group input,
+[data-theme="dark"] .form-group input,
 [data-theme="tint"] .form-group input,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-group select,
+[data-theme="dark"] .form-group select,
 [data-theme="tint"] .form-group select,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form input,
+[data-theme="dark"] .modal-form input,
 [data-theme="tint"] .modal-form input,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form select,
+[data-theme="dark"] .modal-form select,
 [data-theme="tint"] .modal-form select,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form textarea,
+[data-theme="dark"] .modal-form textarea,
 [data-theme="tint"] .modal-form textarea {
     background: var(--ios-bg-secondary);
     border: 1px solid var(--ios-separator);
@@ -1901,20 +1899,20 @@ h1 {
     transition: border-color 0.2s ease, outline 0.2s ease;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-group input:focus,
+[data-theme="dark"] .form-group input:focus,
 [data-theme="tint"] .form-group input:focus,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-group select:focus,
+[data-theme="dark"] .form-group select:focus,
 [data-theme="tint"] .form-group select:focus,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form input:focus,
+[data-theme="dark"] .modal-form input:focus,
 [data-theme="tint"] .modal-form input:focus,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form select:focus,
+[data-theme="dark"] .modal-form select:focus,
 [data-theme="tint"] .modal-form select:focus,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form textarea:focus,
+[data-theme="dark"] .modal-form textarea:focus,
 [data-theme="tint"] .modal-form textarea:focus {
     background: var(--ios-bg-secondary);
     border-color: var(--ios-blue);
@@ -1922,23 +1920,23 @@ h1 {
     outline-offset: -1px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-group input::placeholder,
+[data-theme="dark"] .form-group input::placeholder,
 [data-theme="tint"] .form-group input::placeholder,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form input::placeholder,
+[data-theme="dark"] .modal-form input::placeholder,
 [data-theme="tint"] .modal-form input::placeholder,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form textarea::placeholder,
+[data-theme="dark"] .modal-form textarea::placeholder,
 [data-theme="tint"] .modal-form textarea::placeholder {
     color: var(--ios-label-tertiary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-group label,
+[data-theme="dark"] .form-group label,
 [data-theme="tint"] .form-group label,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form label,
+[data-theme="dark"] .modal-form label,
 [data-theme="tint"] .modal-form label {
     color: var(--ios-label);
     font-weight: 400;
@@ -1946,8 +1944,8 @@ h1 {
 }
 
 /* iOS Form Sections */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-section,
+[data-theme="dark"] .form-section,
 [data-theme="tint"] .form-section {
     background: var(--ios-bg-secondary);
     border-radius: 12px;
@@ -1955,8 +1953,8 @@ h1 {
     border: 1px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-section-title,
+[data-theme="dark"] .form-section-title,
 [data-theme="tint"] .form-section-title {
     color: var(--ios-label-secondary);
     font-size: 13px;
@@ -1966,33 +1964,33 @@ h1 {
     margin-bottom: 16px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-field,
+[data-theme="dark"] .form-field,
 [data-theme="tint"] .form-field {
     margin-bottom: 16px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-row,
+[data-theme="dark"] .form-row,
 [data-theme="tint"] .form-row {
     gap: 16px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .form-row .form-field,
+[data-theme="dark"] .form-row .form-field,
 [data-theme="tint"] .form-row .form-field {
     margin-bottom: 16px;
 }
 
 /* iOS Buttons - Filled style */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .auth-btn,
+[data-theme="dark"] .auth-btn,
 [data-theme="tint"] .auth-btn,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-btn-primary,
+[data-theme="dark"] .modal-btn-primary,
 [data-theme="tint"] .modal-btn-primary,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-todo-btn,
+[data-theme="dark"] .add-todo-btn,
 [data-theme="tint"] .add-todo-btn {
     background: var(--ios-blue);
     color: #ffffff;
@@ -2005,34 +2003,34 @@ h1 {
     transition: all 0.15s ease;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .auth-btn:hover,
+[data-theme="dark"] .auth-btn:hover,
 [data-theme="tint"] .auth-btn:hover,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-btn-primary:hover,
+[data-theme="dark"] .modal-btn-primary:hover,
 [data-theme="tint"] .modal-btn-primary:hover,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-todo-btn:hover,
+[data-theme="dark"] .add-todo-btn:hover,
 [data-theme="tint"] .add-todo-btn:hover {
     background: var(--ios-blue-hover);
     transform: none;
     box-shadow: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .auth-btn:active,
+[data-theme="dark"] .auth-btn:active,
 [data-theme="tint"] .auth-btn:active,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-btn-primary:active,
+[data-theme="dark"] .modal-btn-primary:active,
 [data-theme="tint"] .modal-btn-primary:active,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-todo-btn:active,
+[data-theme="dark"] .add-todo-btn:active,
 [data-theme="tint"] .add-todo-btn:active {
     transform: scale(0.98);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-btn-secondary,
+[data-theme="dark"] .modal-btn-secondary,
 [data-theme="tint"] .modal-btn-secondary {
     background: var(--ios-gray5);
     color: var(--ios-label);
@@ -2042,57 +2040,57 @@ h1 {
     font-size: 17px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-btn-secondary:hover,
+[data-theme="dark"] .modal-btn-secondary:hover,
 [data-theme="tint"] .modal-btn-secondary:hover {
     background: var(--ios-gray4);
 }
 
 /* iOS Checkbox Label */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .checkbox-label,
+[data-theme="dark"] .checkbox-label,
 [data-theme="tint"] .checkbox-label {
     color: var(--ios-label-secondary);
     font-size: 15px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .checkbox-label input[type="checkbox"],
+[data-theme="dark"] .checkbox-label input[type="checkbox"],
 [data-theme="tint"] .checkbox-label input[type="checkbox"] {
     accent-color: var(--ios-blue);
 }
 
 /* iOS Sidebar */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .sidebar,
+[data-theme="dark"] .sidebar,
 [data-theme="tint"] .sidebar {
     background: transparent;
     padding: 1px; /* Prevents Safari from clipping box-shadow on child lists */
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .sidebar h2,
+[data-theme="dark"] .sidebar h2,
 [data-theme="tint"] .sidebar h2 {
     color: var(--ios-label-secondary);
     padding-left: 16px;
     margin-bottom: 8px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .sidebar-section-header,
+[data-theme="dark"] .sidebar-section-header,
 [data-theme="tint"] .sidebar-section-header {
     padding: 5px 16px 5px 0;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .sidebar-section-toggle,
+[data-theme="dark"] .sidebar-section-toggle,
 [data-theme="tint"] .sidebar-section-toggle {
     color: var(--ios-label-tertiary);
 }
 
 /* iOS Grouped List (Categories) */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .category-list,
+[data-theme="dark"] .category-list,
 [data-theme="tint"] .category-list {
     background: var(--ios-bg-secondary);
     border-radius: 12px;
@@ -2100,8 +2098,8 @@ h1 {
     border: 1px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .category-item,
+[data-theme="dark"] .category-item,
 [data-theme="tint"] .category-item {
     background: transparent;
     border: none;
@@ -2113,41 +2111,41 @@ h1 {
     border-bottom: 0.5px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .category-item:last-child,
+[data-theme="dark"] .category-item:last-child,
 [data-theme="tint"] .category-item:last-child {
     border-bottom: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .category-item:hover,
+[data-theme="dark"] .category-item:hover,
 [data-theme="tint"] .category-item:hover {
     background: var(--ios-gray6);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .category-item.active,
+[data-theme="dark"] .category-item.active,
 [data-theme="tint"] .category-item.active {
     background: rgba(0, 122, 255, 0.1);
     color: var(--ios-blue);
     box-shadow: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .category-item.active .category-name,
+[data-theme="dark"] .category-item.active .category-name,
 [data-theme="tint"] .category-item.active .category-name {
     font-weight: 600;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-category-form,
+[data-theme="dark"] .add-category-form,
 [data-theme="tint"] .add-category-form {
     border-top: none;
     padding: 20px 5px 0 5px; /* Horizontal padding for input focus outline */
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-category-input,
+[data-theme="dark"] .add-category-input,
 [data-theme="tint"] .add-category-input {
     background: var(--ios-bg-secondary);
     border: 1px solid var(--ios-separator);
@@ -2156,8 +2154,8 @@ h1 {
     font-size: 15px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-category-input:focus,
+[data-theme="dark"] .add-category-input:focus,
 [data-theme="tint"] .add-category-input:focus {
     background: var(--ios-bg-secondary);
     border-color: var(--ios-blue);
@@ -2165,8 +2163,8 @@ h1 {
     outline-offset: -1px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-category-btn,
+[data-theme="dark"] .add-category-btn,
 [data-theme="tint"] .add-category-btn {
     background: var(--ios-blue);
     color: #ffffff;
@@ -2176,15 +2174,15 @@ h1 {
     transition: background 0.15s ease;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-category-btn:hover,
+[data-theme="dark"] .add-category-btn:hover,
 [data-theme="tint"] .add-category-btn:hover {
     background: var(--ios-blue-hover);
 }
 
 /* iOS Projects Section */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-list,
+[data-theme="dark"] .project-list,
 [data-theme="tint"] .project-list {
     background: var(--ios-bg-secondary);
     border-radius: 12px;
@@ -2192,8 +2190,8 @@ h1 {
     border: 1px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-item,
+[data-theme="dark"] .project-item,
 [data-theme="tint"] .project-item {
     background: transparent;
     border: none;
@@ -2205,42 +2203,42 @@ h1 {
     border-bottom: 0.5px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-item:last-child,
+[data-theme="dark"] .project-item:last-child,
 [data-theme="tint"] .project-item:last-child {
     border-bottom: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-item:hover,
+[data-theme="dark"] .project-item:hover,
 [data-theme="tint"] .project-item:hover {
     background: var(--ios-gray6);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-item.active,
+[data-theme="dark"] .project-item.active,
 [data-theme="tint"] .project-item.active {
     background: rgba(0, 122, 255, 0.1);
     color: var(--ios-blue);
     box-shadow: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-item.active .project-name,
+[data-theme="dark"] .project-item.active .project-name,
 [data-theme="tint"] .project-item.active .project-name {
     font-weight: 600;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-project-form,
+[data-theme="dark"] .add-project-form,
 [data-theme="tint"] .add-project-form {
     border-top: none;
     padding: 20px 5px 0 5px; /* Horizontal padding for input focus outline */
 }
 
 /* iOS Project View Cards */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-card,
+[data-theme="dark"] .project-card,
 [data-theme="tint"] .project-card {
     background: var(--ios-bg-secondary);
     border: 1px solid var(--ios-separator);
@@ -2250,30 +2248,30 @@ h1 {
     margin-bottom: 8px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-card:hover,
+[data-theme="dark"] .project-card:hover,
 [data-theme="tint"] .project-card:hover {
     background: var(--ios-gray6);
     transform: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-card-name,
+[data-theme="dark"] .project-card-name,
 [data-theme="tint"] .project-card-name {
     color: var(--ios-label);
     font-size: 17px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-card-count,
+[data-theme="dark"] .project-card-count,
 [data-theme="tint"] .project-card-count {
     background: var(--ios-gray5);
     color: var(--ios-label-secondary);
     font-size: 13px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-project-input,
+[data-theme="dark"] .add-project-input,
 [data-theme="tint"] .add-project-input {
     background: var(--ios-bg-secondary);
     border: 1px solid var(--ios-separator);
@@ -2282,8 +2280,8 @@ h1 {
     font-size: 15px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-project-input:focus,
+[data-theme="dark"] .add-project-input:focus,
 [data-theme="tint"] .add-project-input:focus {
     background: var(--ios-bg-secondary);
     border-color: var(--ios-blue);
@@ -2291,8 +2289,8 @@ h1 {
     outline-offset: -1px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-project-btn,
+[data-theme="dark"] .add-project-btn,
 [data-theme="tint"] .add-project-btn {
     background: var(--ios-blue);
     color: #ffffff;
@@ -2302,22 +2300,22 @@ h1 {
     transition: background 0.15s ease;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-project-btn:hover,
+[data-theme="dark"] .add-project-btn:hover,
 [data-theme="tint"] .add-project-btn:hover {
     background: var(--ios-blue-hover);
 }
 
 /* iOS Content Area - padding to prevent box-shadow clipping */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .content,
+[data-theme="dark"] .content,
 [data-theme="tint"] .content {
     padding-left: 1px;
 }
 
 /* iOS Todo Items - Grouped list style */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-list,
+[data-theme="dark"] .todo-list,
 [data-theme="tint"] .todo-list {
     background: var(--ios-bg-secondary);
     border-radius: 12px;
@@ -2326,8 +2324,8 @@ h1 {
 }
 
 /* iOS Scheduled Section Headers */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .scheduled-section-header,
+[data-theme="dark"] .scheduled-section-header,
 [data-theme="tint"] .scheduled-section-header {
     background: var(--ios-gray5);
     color: var(--ios-label-secondary);
@@ -2341,50 +2339,50 @@ h1 {
     border-bottom: 0.5px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .scheduled-section-header.overdue,
+[data-theme="dark"] .scheduled-section-header.overdue,
 [data-theme="tint"] .scheduled-section-header.overdue {
     background: rgba(255, 59, 48, 0.15);
     color: var(--ios-red);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .scheduled-section-header.today,
+[data-theme="dark"] .scheduled-section-header.today,
 [data-theme="tint"] .scheduled-section-header.today {
     background: rgba(255, 149, 0, 0.15);
     color: var(--ios-orange);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .scheduled-section-header.tomorrow,
+[data-theme="dark"] .scheduled-section-header.tomorrow,
 [data-theme="tint"] .scheduled-section-header.tomorrow {
     background: rgba(0, 122, 255, 0.15);
     color: var(--ios-blue);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .scheduled-section-header.this-week,
+[data-theme="dark"] .scheduled-section-header.this-week,
 [data-theme="tint"] .scheduled-section-header.this-week {
     background: rgba(175, 82, 222, 0.15);
     color: #af52de;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .scheduled-section-header.next-week,
+[data-theme="dark"] .scheduled-section-header.next-week,
 [data-theme="tint"] .scheduled-section-header.next-week {
     background: rgba(52, 199, 89, 0.15);
     color: #34c759;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .scheduled-section-header.later,
+[data-theme="dark"] .scheduled-section-header.later,
 [data-theme="tint"] .scheduled-section-header.later {
     background: var(--ios-gray5);
     color: var(--ios-label-secondary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-item,
+[data-theme="dark"] .todo-item,
 [data-theme="tint"] .todo-item {
     background: transparent;
     border: none;
@@ -2396,83 +2394,83 @@ h1 {
     transition: background 0.15s ease;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-item:last-child,
+[data-theme="dark"] .todo-item:last-child,
 [data-theme="tint"] .todo-item:last-child {
     border-bottom: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-item:hover,
+[data-theme="dark"] .todo-item:hover,
 [data-theme="tint"] .todo-item:hover {
     background: var(--ios-gray6);
     transform: none;
     box-shadow: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-item.completed,
+[data-theme="dark"] .todo-item.completed,
 [data-theme="tint"] .todo-item.completed {
     opacity: 0.5;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .drag-handle,
+[data-theme="dark"] .drag-handle,
 [data-theme="tint"] .drag-handle {
     color: var(--ios-label-tertiary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .drag-handle:hover,
+[data-theme="dark"] .drag-handle:hover,
 [data-theme="tint"] .drag-handle:hover {
     color: var(--ios-label-secondary);
     background-color: var(--ios-gray5);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-item.dragging .drag-handle,
+[data-theme="dark"] .todo-item.dragging .drag-handle,
 [data-theme="tint"] .todo-item.dragging .drag-handle {
     color: white;
     background-color: var(--ios-blue);
     transform: scale(1.15);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-text,
+[data-theme="dark"] .todo-text,
 [data-theme="tint"] .todo-text {
     color: var(--ios-label);
     font-size: 17px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-comment,
+[data-theme="dark"] .todo-comment,
 [data-theme="tint"] .todo-comment {
     color: var(--ios-label-secondary);
     font-size: 14px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-item.completed .todo-text,
+[data-theme="dark"] .todo-item.completed .todo-text,
 [data-theme="tint"] .todo-item.completed .todo-text {
     color: var(--ios-label-tertiary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-item.completed .todo-comment,
+[data-theme="dark"] .todo-item.completed .todo-comment,
 [data-theme="tint"] .todo-item.completed .todo-comment {
     color: var(--ios-label-tertiary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-checkbox,
+[data-theme="dark"] .todo-checkbox,
 [data-theme="tint"] .todo-checkbox {
     width: 22px;
     height: 22px;
     accent-color: var(--ios-blue);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .delete-btn,
+[data-theme="dark"] .delete-btn,
 [data-theme="tint"] .delete-btn {
     background: var(--ios-red);
     border: none;
@@ -2482,18 +2480,18 @@ h1 {
     font-weight: 500;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .delete-btn:hover,
+[data-theme="dark"] .delete-btn:hover,
 [data-theme="tint"] .delete-btn:hover {
     background: #e62e24;
 }
 
 /* iOS Badges */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-category-badge,
+[data-theme="dark"] .todo-category-badge,
 [data-theme="tint"] .todo-category-badge,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-priority-badge,
+[data-theme="dark"] .todo-priority-badge,
 [data-theme="tint"] .todo-priority-badge {
     border-radius: 6px;
     font-size: 12px;
@@ -2501,8 +2499,8 @@ h1 {
     padding: 3px 8px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-date,
+[data-theme="dark"] .todo-date,
 [data-theme="tint"] .todo-date {
     background: var(--ios-gray5);
     color: var(--ios-label-secondary);
@@ -2512,65 +2510,65 @@ h1 {
     padding: 3px 8px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-date.overdue,
+[data-theme="dark"] .todo-date.overdue,
 [data-theme="tint"] .todo-date.overdue {
     background: rgba(255, 59, 48, 0.15);
     color: var(--ios-red);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-date.today,
+[data-theme="dark"] .todo-date.today,
 [data-theme="tint"] .todo-date.today {
     background: rgba(255, 149, 0, 0.15);
     color: var(--ios-orange);
 }
 
 /* iOS Stats */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .stats,
+[data-theme="dark"] .stats,
 [data-theme="tint"] .stats {
     color: var(--ios-label-secondary);
     border-top-color: var(--ios-separator);
     font-size: 13px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .export-btn,
+[data-theme="dark"] .export-btn,
 [data-theme="tint"] .export-btn {
     background: var(--ios-blue);
     border-radius: 8px;
     font-weight: 500;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .export-btn:hover,
+[data-theme="dark"] .export-btn:hover,
 [data-theme="tint"] .export-btn:hover {
     background: var(--ios-blue-hover);
 }
 
 /* iOS User Header */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .user-header,
+[data-theme="dark"] .user-header,
 [data-theme="tint"] .user-header {
     border-top-color: var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .user-display,
+[data-theme="dark"] .user-display,
 [data-theme="tint"] .user-display {
     color: var(--ios-label);
     font-weight: 600;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .user-email,
+[data-theme="dark"] .user-email,
 [data-theme="tint"] .user-email {
     color: var(--ios-label-tertiary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .settings-btn,
+[data-theme="dark"] .settings-btn,
 [data-theme="tint"] .settings-btn {
     background: var(--ios-gray5);
     color: var(--ios-label);
@@ -2580,14 +2578,14 @@ h1 {
     transition: background 0.15s ease;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .settings-btn:hover,
+[data-theme="dark"] .settings-btn:hover,
 [data-theme="tint"] .settings-btn:hover {
     background: var(--ios-gray4);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .lock-btn,
+[data-theme="dark"] .lock-btn,
 [data-theme="tint"] .lock-btn {
     background: var(--ios-gray5);
     color: var(--ios-label);
@@ -2596,14 +2594,14 @@ h1 {
     transition: background 0.15s ease;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .lock-btn:hover,
+[data-theme="dark"] .lock-btn:hover,
 [data-theme="tint"] .lock-btn:hover {
     background: var(--ios-gray4);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .logout-btn,
+[data-theme="dark"] .logout-btn,
 [data-theme="tint"] .logout-btn {
     background: var(--ios-red);
     border: none;
@@ -2611,33 +2609,33 @@ h1 {
     transition: background 0.15s ease;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .logout-btn:hover,
+[data-theme="dark"] .logout-btn:hover,
 [data-theme="tint"] .logout-btn:hover {
     background: #e62e24;
 }
 
 /* iOS Footer */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .app-footer,
+[data-theme="dark"] .app-footer,
 [data-theme="tint"] .app-footer {
     border-top-color: var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .app-version,
+[data-theme="dark"] .app-version,
 [data-theme="tint"] .app-version {
     color: var(--ios-label-tertiary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .theme-selector label,
+[data-theme="dark"] .theme-selector label,
 [data-theme="tint"] .theme-selector label {
     color: var(--ios-label-secondary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .theme-selector select,
+[data-theme="dark"] .theme-selector select,
 [data-theme="tint"] .theme-selector select {
     background: var(--ios-bg-secondary);
     border: 1px solid var(--ios-separator);
@@ -2646,21 +2644,21 @@ h1 {
     padding: 8px 12px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .app-footer-links a,
+[data-theme="dark"] .app-footer-links a,
 [data-theme="tint"] .app-footer-links a {
     color: var(--ios-blue);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .app-footer-links a:hover,
+[data-theme="dark"] .app-footer-links a:hover,
 [data-theme="tint"] .app-footer-links a:hover {
     color: var(--ios-blue-hover);
 }
 
 /* iOS Modal Overlay */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-overlay,
+[data-theme="dark"] .modal-overlay,
 [data-theme="tint"] .modal-overlay {
     background: rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(var(--ios-blur-thin));
@@ -2668,8 +2666,8 @@ h1 {
 }
 
 /* iOS Modal - Sheet style */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal,
+[data-theme="dark"] .modal,
 [data-theme="tint"] .modal {
     background: var(--ios-bg-grouped);
     backdrop-filter: blur(var(--ios-blur-thick));
@@ -2681,22 +2679,22 @@ h1 {
     max-width: 720px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-form,
+[data-theme="dark"] .modal-form,
 [data-theme="tint"] .modal-form {
     gap: 16px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-header,
+[data-theme="dark"] .modal-header,
 [data-theme="tint"] .modal-header {
     border-bottom: 0.5px solid var(--ios-separator);
     padding-bottom: 16px;
     margin-bottom: 8px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-header h2,
+[data-theme="dark"] .modal-header h2,
 [data-theme="tint"] .modal-header h2 {
     color: var(--ios-label);
     font-size: 17px;
@@ -2705,8 +2703,8 @@ h1 {
     letter-spacing: 0;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-close,
+[data-theme="dark"] .modal-close,
 [data-theme="tint"] .modal-close {
     color: var(--ios-gray);
     background: var(--ios-gray5);
@@ -2716,42 +2714,42 @@ h1 {
     font-size: 20px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .modal-close:hover,
+[data-theme="dark"] .modal-close:hover,
 [data-theme="tint"] .modal-close:hover {
     background: var(--ios-gray4);
     color: var(--ios-label);
 }
 
 /* iOS Empty State */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .empty-state,
+[data-theme="dark"] .empty-state,
 [data-theme="tint"] .empty-state {
     color: var(--ios-label-tertiary);
     font-size: 15px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .inbox-zen-state .zen-title,
+[data-theme="dark"] .inbox-zen-state .zen-title,
 [data-theme="tint"] .inbox-zen-state .zen-title {
     color: var(--ios-blue);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .inbox-zen-state .zen-message,
+[data-theme="dark"] .inbox-zen-state .zen-message,
 [data-theme="tint"] .inbox-zen-state .zen-message {
     color: var(--ios-label-secondary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .inbox-zen-state .zen-illustration,
+[data-theme="dark"] .inbox-zen-state .zen-illustration,
 [data-theme="tint"] .inbox-zen-state .zen-illustration {
     opacity: 0.9;
 }
 
 /* iOS Messages */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .error-message,
+[data-theme="dark"] .error-message,
 [data-theme="tint"] .error-message {
     background: rgba(255, 59, 48, 0.12);
     color: var(--ios-red);
@@ -2760,8 +2758,8 @@ h1 {
     font-size: 14px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .success-message,
+[data-theme="dark"] .success-message,
 [data-theme="tint"] .success-message {
     background: rgba(52, 199, 89, 0.12);
     color: #34c759;
@@ -2771,8 +2769,8 @@ h1 {
 }
 
 /* iOS Category Colors */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .category-color,
+[data-theme="dark"] .category-color,
 [data-theme="tint"] .category-color {
     width: 10px;
     height: 10px;
@@ -2783,14 +2781,14 @@ h1 {
    ======================================== */
 
 /* iOS GTD Section */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-section,
+[data-theme="dark"] .gtd-section,
 [data-theme="tint"] .gtd-section {
     margin-bottom: 20px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-list,
+[data-theme="dark"] .gtd-list,
 [data-theme="tint"] .gtd-list {
     background: var(--ios-bg-secondary);
     border-radius: 12px;
@@ -2798,8 +2796,8 @@ h1 {
     border: 1px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-item,
+[data-theme="dark"] .gtd-item,
 [data-theme="tint"] .gtd-item {
     background: transparent;
     border: none;
@@ -2810,59 +2808,59 @@ h1 {
     border-bottom: 0.5px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-item:last-child,
+[data-theme="dark"] .gtd-item:last-child,
 [data-theme="tint"] .gtd-item:last-child {
     border-bottom: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-item:hover,
+[data-theme="dark"] .gtd-item:hover,
 [data-theme="tint"] .gtd-item:hover {
     background: var(--ios-gray6);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-item.active,
+[data-theme="dark"] .gtd-item.active,
 [data-theme="tint"] .gtd-item.active {
     background: rgba(0, 122, 255, 0.1);
     color: var(--ios-blue);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-item.active .gtd-icon,
+[data-theme="dark"] .gtd-item.active .gtd-icon,
 [data-theme="tint"] .gtd-item.active .gtd-icon {
     color: var(--ios-blue);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-item.active .gtd-count,
+[data-theme="dark"] .gtd-item.active .gtd-count,
 [data-theme="tint"] .gtd-item.active .gtd-count {
     color: var(--ios-blue);
     opacity: 0.7;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-icon,
+[data-theme="dark"] .gtd-icon,
 [data-theme="tint"] .gtd-icon {
     opacity: 0.8;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-count,
+[data-theme="dark"] .gtd-count,
 [data-theme="tint"] .gtd-count {
     color: var(--ios-label-tertiary);
 }
 
 /* iOS Contexts Section */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .contexts-header,
+[data-theme="dark"] .contexts-header,
 [data-theme="tint"] .contexts-header {
     color: var(--ios-label-secondary);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .context-list,
+[data-theme="dark"] .context-list,
 [data-theme="tint"] .context-list {
     background: var(--ios-bg-secondary);
     border-radius: 12px;
@@ -2870,8 +2868,8 @@ h1 {
     border: 1px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .context-item,
+[data-theme="dark"] .context-item,
 [data-theme="tint"] .context-item {
     background: transparent;
     border: none;
@@ -2882,37 +2880,37 @@ h1 {
     border-bottom: 0.5px solid var(--ios-separator);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .context-item:last-child,
+[data-theme="dark"] .context-item:last-child,
 [data-theme="tint"] .context-item:last-child {
     border-bottom: none;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .context-item:hover,
+[data-theme="dark"] .context-item:hover,
 [data-theme="tint"] .context-item:hover {
     background: var(--ios-gray6);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .context-item.active,
+[data-theme="dark"] .context-item.active,
 [data-theme="tint"] .context-item.active {
     background: rgba(0, 122, 255, 0.1);
     color: var(--ios-blue);
 }
 
 /* Glass theme drag-over states */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .category-item.drag-over,
+[data-theme="dark"] .category-item.drag-over,
 [data-theme="tint"] .category-item.drag-over,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .context-item.drag-over,
+[data-theme="dark"] .context-item.drag-over,
 [data-theme="tint"] .context-item.drag-over,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .gtd-item.drag-over,
+[data-theme="dark"] .gtd-item.drag-over,
 [data-theme="tint"] .gtd-item.drag-over,
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .project-item.drag-over,
+[data-theme="dark"] .project-item.drag-over,
 [data-theme="tint"] .project-item.drag-over {
     background: var(--ios-blue) !important;
     color: white !important;
@@ -2920,14 +2918,14 @@ h1 {
     box-shadow: 0 2px 8px rgba(0, 122, 255, 0.3);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-context-form,
+[data-theme="dark"] .add-context-form,
 [data-theme="tint"] .add-context-form {
     padding: 0 5px; /* Horizontal padding for input focus outline */
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-context-input,
+[data-theme="dark"] .add-context-input,
 [data-theme="tint"] .add-context-input {
     background: var(--ios-bg-secondary);
     border: 1px solid var(--ios-separator);
@@ -2936,16 +2934,16 @@ h1 {
     font-size: 15px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-context-input:focus,
+[data-theme="dark"] .add-context-input:focus,
 [data-theme="tint"] .add-context-input:focus {
     border-color: var(--ios-blue);
     outline: 4px solid rgba(0, 122, 255, 0.15);
     outline-offset: -1px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-context-btn,
+[data-theme="dark"] .add-context-btn,
 [data-theme="tint"] .add-context-btn {
     background: var(--ios-blue);
     color: #ffffff;
@@ -2954,15 +2952,15 @@ h1 {
     font-weight: 600;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .add-context-btn:hover,
+[data-theme="dark"] .add-context-btn:hover,
 [data-theme="tint"] .add-context-btn:hover {
     background: var(--ios-blue-hover);
 }
 
 /* iOS GTD Badges */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-gtd-badge,
+[data-theme="dark"] .todo-gtd-badge,
 [data-theme="tint"] .todo-gtd-badge {
     border-radius: 6px;
     font-size: 12px;
@@ -2970,51 +2968,51 @@ h1 {
     padding: 3px 8px;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-gtd-badge.inbox,
+[data-theme="dark"] .todo-gtd-badge.inbox,
 [data-theme="tint"] .todo-gtd-badge.inbox {
     background: rgba(0, 122, 255, 0.15);
     color: var(--ios-blue);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-gtd-badge.next_action,
+[data-theme="dark"] .todo-gtd-badge.next_action,
 [data-theme="tint"] .todo-gtd-badge.next_action {
     background: rgba(52, 199, 89, 0.15);
     color: #34c759;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-gtd-badge.scheduled,
+[data-theme="dark"] .todo-gtd-badge.scheduled,
 [data-theme="tint"] .todo-gtd-badge.scheduled {
     background: rgba(255, 45, 85, 0.15);
     color: #ff2d55;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-gtd-badge.waiting_for,
+[data-theme="dark"] .todo-gtd-badge.waiting_for,
 [data-theme="tint"] .todo-gtd-badge.waiting_for {
     background: rgba(255, 149, 0, 0.15);
     color: var(--ios-orange);
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-gtd-badge.someday_maybe,
+[data-theme="dark"] .todo-gtd-badge.someday_maybe,
 [data-theme="tint"] .todo-gtd-badge.someday_maybe {
     background: rgba(175, 82, 222, 0.15);
     color: #af52de;
 }
 
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-gtd-badge.done,
+[data-theme="dark"] .todo-gtd-badge.done,
 [data-theme="tint"] .todo-gtd-badge.done {
     background: rgba(52, 199, 89, 0.15);
     color: #34c759;
 }
 
 /* iOS Context Badge */
-[data-theme="glass"],
-[data-theme="dark"],
+[data-theme="glass"] .todo-context-badge,
+[data-theme="dark"] .todo-context-badge,
 [data-theme="tint"] .todo-context-badge {
     background: var(--ios-gray5);
     color: var(--ios-label-secondary);


### PR DESCRIPTION
## Summary
Fixes broken CSS theme selectors that were causing the app to display incorrectly.

## Problem
The previous PR (#125) introduced malformed CSS selectors. When replacing `[data-theme="glass"]` with multi-theme selectors, the element selector was not repeated for each theme:

**Broken:**
```css
[data-theme="glass"],
[data-theme="dark"],
[data-theme="tint"] .element { ... }
```

This selector matches:
- Any element with `data-theme="glass"`
- Any element with `data-theme="dark"`
- `.element` inside `data-theme="tint"`

**Correct:**
```css
[data-theme="glass"] .element,
[data-theme="dark"] .element,
[data-theme="tint"] .element { ... }
```

## Solution
- Fixed all 167 CSS selectors to properly repeat the element selector for each theme
- Fixed the Glass theme variable definition which was incorrectly merged with Dark/Tint

## Testing
- [x] CSS syntax is now valid
- [x] All three themes should now apply their styles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)