### PR TITLE
fix: Refine Tint theme and improve theme-specific styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -130,17 +130,17 @@
     --accent-hover: var(--ios-blue-hover);
 }
 
-/* Tint Theme - Colored tint overlay (macOS/iOS style) */
+/* Tint Theme - Subtle multicolor tint (macOS/iOS style) */
 [data-theme="tint"] {
-    /* Tinted System Background Colors - subtle purple/blue tint */
-    --ios-bg-primary: #f0f0f8;
+    /* Tinted System Background Colors - very subtle warm tint like macOS */
+    --ios-bg-primary: #f5f5f7;
     --ios-bg-secondary: #ffffff;
-    --ios-bg-tertiary: #e8e8f4;
-    --ios-bg-grouped: #f0f0f8;
+    --ios-bg-tertiary: #f5f5f7;
+    --ios-bg-grouped: #f5f5f7;
 
-    /* iOS System Colors with tint */
-    --ios-blue: #5856d6;
-    --ios-blue-hover: #4240a8;
+    /* Standard iOS System Colors - keep blue for consistency */
+    --ios-blue: #007aff;
+    --ios-blue-hover: #0056b3;
     --ios-gray: #8e8e93;
     --ios-gray2: #aeaeb2;
     --ios-gray3: #c7c7cc;
@@ -150,30 +150,30 @@
     --ios-red: #ff3b30;
     --ios-orange: #ff9500;
 
-    /* Tinted Label Colors */
-    --ios-label: #1c1c3c;
-    --ios-label-secondary: #3c3c5c;
-    --ios-label-tertiary: #3c3c5c99;
-    --ios-label-quaternary: #3c3c5c4d;
+    /* Standard Label Colors */
+    --ios-label: #000000;
+    --ios-label-secondary: #3c3c43;
+    --ios-label-tertiary: #3c3c4399;
+    --ios-label-quaternary: #3c3c434d;
 
-    /* Tinted Material */
-    --ios-material-thick: rgba(248, 248, 255, 0.92);
-    --ios-material-regular: rgba(248, 248, 255, 0.85);
-    --ios-material-thin: rgba(248, 248, 255, 0.75);
-    --ios-material-ultrathin: rgba(248, 248, 255, 0.55);
+    /* Tinted Material - subtle warm tint */
+    --ios-material-thick: rgba(255, 253, 250, 0.92);
+    --ios-material-regular: rgba(255, 253, 250, 0.85);
+    --ios-material-thin: rgba(255, 253, 250, 0.75);
+    --ios-material-ultrathin: rgba(255, 253, 250, 0.55);
 
     /* iOS Blur */
     --ios-blur-thick: 50px;
     --ios-blur-regular: 40px;
     --ios-blur-thin: 30px;
 
-    /* Tinted Separator */
-    --ios-separator: rgba(88, 86, 214, 0.12);
-    --ios-separator-opaque: #d0d0e8;
+    /* Standard Separator */
+    --ios-separator: rgba(60, 60, 67, 0.12);
+    --ios-separator-opaque: #c6c6c8;
 
-    /* Theme mapping */
-    --primary-start: #e0e0f0;
-    --primary-end: #f0f0f8;
+    /* Theme mapping - subtle gradient */
+    --primary-start: #faf8f5;
+    --primary-end: #f5f5f7;
     --accent-color: var(--ios-blue);
     --accent-hover: var(--ios-blue-hover);
 }
@@ -219,6 +219,16 @@
     font-size: 15px;
     color: #666;
     font-weight: 500;
+}
+
+/* Dark theme loading screen */
+[data-theme="dark"] .loading-spinner {
+    border-color: rgba(255, 255, 255, 0.1);
+    border-top-color: #ffffff;
+}
+
+[data-theme="dark"] .loading-text {
+    color: #ebebf5;
 }
 
 @keyframes spin {
@@ -1776,18 +1786,29 @@ h1 {
    Glass Theme - iOS 26 Authentic Design
    ======================================== */
 
-/* iOS Background - Subtle light gradient */
-[data-theme="glass"] body,
-[data-theme="dark"] body,
-[data-theme="tint"] body {
+/* iOS Background - Glass Theme */
+[data-theme="glass"] body {
     background: var(--ios-bg-grouped);
     background-image: linear-gradient(180deg, #ffffff 0%, var(--ios-gray6) 100%);
     background-attachment: fixed;
 }
 
-/* iOS Container - Thick material */
+/* iOS Background - Dark Theme */
+[data-theme="dark"] body {
+    background: #000000;
+    background-image: linear-gradient(180deg, #1c1c1e 0%, #000000 100%);
+    background-attachment: fixed;
+}
+
+/* iOS Background - Tint Theme (subtle macOS-style multicolor) */
+[data-theme="tint"] body {
+    background: #f5f5f7;
+    background-image: linear-gradient(135deg, #fef6f0 0%, #f0f5fe 50%, #f5f0fe 100%);
+    background-attachment: fixed;
+}
+
+/* iOS Container - Glass & Tint (light themes) */
 [data-theme="glass"] .container,
-[data-theme="dark"] .container,
 [data-theme="tint"] .container {
     background: var(--ios-material-thick);
     backdrop-filter: blur(var(--ios-blur-thick));
@@ -1795,6 +1816,17 @@ h1 {
     border: none;
     box-shadow: 0 0 0 0.5px var(--ios-separator-opaque),
                 0 2px 10px rgba(0, 0, 0, 0.08);
+    border-radius: 20px;
+}
+
+/* iOS Container - Dark Theme */
+[data-theme="dark"] .container {
+    background: var(--ios-material-thick);
+    backdrop-filter: blur(var(--ios-blur-thick));
+    -webkit-backdrop-filter: blur(var(--ios-blur-thick));
+    border: none;
+    box-shadow: 0 0 0 0.5px var(--ios-separator-opaque),
+                0 4px 20px rgba(0, 0, 0, 0.4);
     border-radius: 20px;
 }
 
@@ -2004,17 +2036,23 @@ h1 {
 }
 
 [data-theme="glass"] .auth-btn:hover,
-[data-theme="dark"] .auth-btn:hover,
 [data-theme="tint"] .auth-btn:hover,
 [data-theme="glass"] .modal-btn-primary:hover,
-[data-theme="dark"] .modal-btn-primary:hover,
 [data-theme="tint"] .modal-btn-primary:hover,
 [data-theme="glass"] .add-todo-btn:hover,
-[data-theme="dark"] .add-todo-btn:hover,
 [data-theme="tint"] .add-todo-btn:hover {
     background: var(--ios-blue-hover);
     transform: none;
     box-shadow: none;
+}
+
+/* Dark theme buttons with subtle glow */
+[data-theme="dark"] .auth-btn:hover,
+[data-theme="dark"] .modal-btn-primary:hover,
+[data-theme="dark"] .add-todo-btn:hover {
+    background: var(--ios-blue-hover);
+    transform: none;
+    box-shadow: 0 0 12px rgba(10, 132, 255, 0.4);
 }
 
 [data-theme="glass"] .auth-btn:active,
@@ -2481,9 +2519,13 @@ h1 {
 }
 
 [data-theme="glass"] .delete-btn:hover,
-[data-theme="dark"] .delete-btn:hover,
 [data-theme="tint"] .delete-btn:hover {
     background: #e62e24;
+}
+
+[data-theme="dark"] .delete-btn:hover {
+    background: #ff453a;
+    box-shadow: 0 0 10px rgba(255, 69, 58, 0.4);
 }
 
 /* iOS Badges */


### PR DESCRIPTION
## Summary
Refines the Tint theme to be more subtle like macOS/iOS and adds proper theme-specific styling for buttons and other elements.

## Changes

### Tint Theme (completely redesigned)
**Before:** Heavy purple coloring that was too saturated
**After:** Subtle macOS-style appearance
- Standard iOS blue for buttons (not purple)
- Very subtle multicolor background gradient (peach → blue → lavender)
- Standard black label colors
- Subtle warm tint on materials

### Theme-Specific Backgrounds
| Theme | Background |
|-------|-----------|
| Glass | White → light gray gradient |
| Dark | Dark gray → black gradient |
| Tint | Subtle peach → blue → lavender gradient |

### Button Styling
- **Glass/Tint:** Standard iOS blue buttons
- **Dark:** Blue buttons with subtle glow on hover (`box-shadow: 0 0 12px rgba(10, 132, 255, 0.4)`)

### Delete Button
- **Glass/Tint:** Standard red
- **Dark:** Red with subtle glow on hover

### Other Improvements
- Dark theme container has stronger shadow for depth
- Dark theme loading spinner uses white colors
- Dark theme loading text uses light color

## Testing
- [x] Glass theme looks correct
- [x] Dark theme has proper dark styling with glows
- [x] Tint theme is now subtle and macOS-like

🤖 Generated with [Claude Code](https://claude.com/claude-code)