### PR TITLE
UI: Add Refresh button to reload data from database (fixes #136)

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,6 +127,7 @@ class TodoApp {
         this.userDisplay = document.getElementById('userDisplay')
         this.userEmail = document.getElementById('userEmail')
         this.settingsBtn = document.getElementById('settingsBtn')
+        this.refreshBtn = document.getElementById('refreshBtn')
         this.lockBtn = document.getElementById('lockBtn')
         this.logoutBtn = document.getElementById('logoutBtn')
         this.settingsModal = document.getElementById('settingsModal')
@@ -261,6 +262,9 @@ class TodoApp {
         this.logoutBtn.addEventListener('click', async () => {
             await this.handleLogout()
         })
+
+        // Refresh data
+        this.refreshBtn.addEventListener('click', () => this.refreshData())
 
         // Settings modal controls
         this.settingsBtn.addEventListener('click', () => this.openSettingsModal())
@@ -465,6 +469,26 @@ class TodoApp {
         this.loadingScreen.classList.add('hidden')
         this.mainContainer.classList.remove('loading')
         this.mainContainer.classList.add('loaded')
+    }
+
+    async refreshData() {
+        this.refreshBtn.disabled = true
+        this.refreshBtn.textContent = 'Refreshing...'
+
+        try {
+            await Promise.all([
+                this.loadCategories(),
+                this.loadPriorities(),
+                this.loadContexts(),
+                this.loadProjects(),
+                this.loadTodos()
+            ])
+        } catch (error) {
+            console.error('Error refreshing data:', error)
+        } finally {
+            this.refreshBtn.disabled = false
+            this.refreshBtn.textContent = 'Refresh'
+        }
     }
 
     handleSignOut() {

--- a/index.html
+++ b/index.html
@@ -164,6 +164,7 @@
                 <div class="user-actions">
                     <button id="lockBtn" class="lock-btn" aria-label="Lock application">🔒</button>
                     <button id="settingsBtn" class="settings-btn">Settings</button>
+                    <button id="refreshBtn" class="refresh-btn" aria-label="Refresh data">Refresh</button>
                     <button id="logoutBtn" class="logout-btn">Logout</button>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -455,6 +455,21 @@ h1 {
     background: var(--accent-hover);
 }
 
+.refresh-btn {
+    padding: 8px 15px;
+    background: #6c757d;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background 0.3s;
+}
+
+.refresh-btn:hover {
+    background: #5a6268;
+}
+
 .logout-btn {
     padding: 8px 15px;
     background: #e74c3c;
@@ -2922,6 +2937,23 @@ h1 {
 [data-theme="glass"] .settings-btn:hover,
 [data-theme="dark"] .settings-btn:hover,
 [data-theme="clear"] .settings-btn:hover {
+    background: var(--ios-gray4);
+}
+
+[data-theme="glass"] .refresh-btn,
+[data-theme="dark"] .refresh-btn,
+[data-theme="clear"] .refresh-btn {
+    background: var(--ios-gray5);
+    color: var(--ios-label);
+    border: none;
+    border-radius: 8px;
+    font-weight: 500;
+    transition: background 0.15s ease;
+}
+
+[data-theme="glass"] .refresh-btn:hover,
+[data-theme="dark"] .refresh-btn:hover,
+[data-theme="clear"] .refresh-btn:hover {
     background: var(--ios-gray4);
 }
 


### PR DESCRIPTION
## Summary
Add a Refresh button in the user actions area that reloads all data from the database when clicked.

## Problem
Users had no way to manually refresh their data from the database without reloading the entire page. This is useful when data may have been modified from another device or browser tab.

## Solution
Added a new Refresh button between the Settings and Logout buttons that:
- Reloads all data (categories, priorities, contexts, projects, and todos) from Supabase
- Shows a "Refreshing..." state while loading
- Disables the button during refresh to prevent double-clicks

## Changes
- `index.html`: Added refreshBtn element with aria-label for accessibility
- `styles.css`: Added .refresh-btn styling with neutral gray color, plus theme support for glass/dark/clear themes
- `app.js`: Added DOM reference, event listener, and refreshData() method

## Testing
- [x] Button renders correctly between Settings and Logout
- [x] CSS styles verified (base + theme variants)
- [x] JavaScript method implemented with proper error handling

Fixes #136

Generated with [Claude Code](https://claude.com/claude-code)