### PR TITLE
UI: Make application extend to full screen when logged in

### DIFF
--- a/app.js
+++ b/app.js
@@ -447,6 +447,7 @@ class TodoApp {
         this.authContainer.classList.remove('active')
         this.appContainer.classList.add('active')
         this.mainContainer.classList.remove('auth-mode')
+        document.body.classList.add('fullscreen-mode')
 
         // Load data and wait for essential items
         await Promise.all([
@@ -505,6 +506,7 @@ class TodoApp {
         this.authContainer.classList.add('active')
         this.appContainer.classList.remove('active')
         this.mainContainer.classList.add('auth-mode')
+        document.body.classList.remove('fullscreen-mode')
         this.loginForm.reset()
         this.signupForm.reset()
         this.authMessage.innerHTML = ''

--- a/styles.css
+++ b/styles.css
@@ -256,6 +256,21 @@ body {
     padding: 20px;
 }
 
+/* Fullscreen mode - applied when user is logged in */
+body.fullscreen-mode {
+    padding: 0;
+    align-items: stretch;
+}
+
+body.fullscreen-mode .container {
+    max-width: none;
+    border-radius: 0;
+    box-shadow: none;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
 .container {
     background: white;
     border-radius: 15px;
@@ -406,7 +421,29 @@ h1 {
 }
 
 .app-container.active {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+/* Make main content area expand in fullscreen mode */
+body.fullscreen-mode .app-container.active {
+    min-height: 0;
+}
+
+body.fullscreen-mode .main-content {
+    flex: 1;
+    min-height: 0;
+}
+
+body.fullscreen-mode .content {
+    display: flex;
+    flex-direction: column;
+}
+
+body.fullscreen-mode .todo-list {
+    flex: 1;
+    overflow-y: auto;
 }
 
 .user-header {
@@ -2024,6 +2061,14 @@ h1 {
     box-shadow: 0 0 0 0.5px var(--ios-separator-opaque),
                 0 4px 20px rgba(0, 0, 0, 0.4);
     border-radius: 20px;
+}
+
+/* iOS Container - Fullscreen mode overrides */
+[data-theme="glass"] body.fullscreen-mode .container,
+[data-theme="dark"] body.fullscreen-mode .container,
+[data-theme="clear"] body.fullscreen-mode .container {
+    border-radius: 0;
+    box-shadow: none;
 }
 
 /* iOS Typography */


### PR DESCRIPTION
## Summary

Fixes #138

- App container fills the entire viewport when the user is logged in
- Auth form remains centered with the current card-style layout
- Works correctly with all three themes (Glass, Dark, Clear)
- Sidebar and content area expand to fill available space
- Todo list becomes scrollable when content exceeds viewport height

## Test plan

- [ ] Log in and verify the app fills the entire screen
- [ ] Verify auth form is still centered when logged out
- [ ] Test with Glass theme
- [ ] Test with Dark theme
- [ ] Test with Clear theme
- [ ] Test on mobile/tablet viewport sizes
- [ ] Verify logout returns to centered auth form

🤖 Generated with [Claude Code](https://claude.com/claude-code)