### PR TITLE
UI: Remove TodoList text from header

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
                 <circle cx="16" cy="16" r="14" fill="url(#iconGradient)"/>
                 <path d="M10 16.5L14 20.5L22 12.5" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span class="app-title">TodoList</span>
         </h1>
 
         <!-- Authentication UI -->


### PR DESCRIPTION
## Summary
- Removes the "TodoList" text from the application header to provide more vertical space for todos
- Retains the checkmark icon as the app identifier

## Test plan
- [ ] Verify the header displays only the checkmark icon
- [ ] Confirm the layout still looks balanced without the text
- [ ] Test on mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)