### PR TITLE
UI: Move Export button to toolbar and remove stats section

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,8 +169,6 @@ class TodoApp {
         this.projectsSection = document.getElementById('projectsSection')
         this.modalProjectSelect = document.getElementById('modalProjectSelect')
         this.gtdList = document.getElementById('gtdList')
-        this.totalTodosEl = document.getElementById('totalTodos')
-        this.completedTodosEl = document.getElementById('completedTodos')
         this.exportBtn = document.getElementById('exportBtn')
         this.versionNumberEl = document.getElementById('versionNumber')
         this.themeSelect = document.getElementById('themeSelect')
@@ -1932,11 +1930,6 @@ class TodoApp {
 
     updateStats() {
         const filteredTodos = this.getFilteredTodos()
-        const total = filteredTodos.length
-        // Use gtd_status for completed count (unified status)
-        const completed = filteredTodos.filter(t => t.gtd_status === 'done').length
-        this.totalTodosEl.textContent = `Total: ${total}`
-        this.completedTodosEl.textContent = `Completed: ${completed}`
     }
 
     renderProjectsView() {
@@ -1963,9 +1956,7 @@ class TodoApp {
     }
 
     updateProjectsViewStats() {
-        const totalItems = this.projects.reduce((sum, p) => sum + this.getProjectTodoCount(p.id), 0)
-        this.totalTodosEl.textContent = `Projects: ${this.projects.length}`
-        this.completedTodosEl.textContent = `Items: ${totalItems}`
+        // Stats display removed - method kept for compatibility
     }
 
     renderTodos() {

--- a/index.html
+++ b/index.html
@@ -152,6 +152,7 @@
                     <div class="content-toolbar">
                         <button id="openAddTodoModal" class="toolbar-btn add-todo-btn">+ Add Todo</button>
                         <div class="toolbar-spacer"></div>
+                        <button id="exportBtn" class="toolbar-btn toolbar-btn-secondary" aria-label="Export current list">Export</button>
                         <div class="toolbar-user-menu" id="toolbarUserMenu">
                             <button class="toolbar-user-btn" id="toolbarUserBtn" aria-haspopup="true" aria-expanded="false">
                                 <span class="toolbar-username" id="toolbarUsername"></span>
@@ -168,12 +169,6 @@
                     </div>
 
                     <ul id="todoList" class="todo-list"></ul>
-
-                    <div class="stats">
-                        <span id="totalTodos">Total: 0</span>
-                        <span id="completedTodos">Completed: 0</span>
-                        <button id="exportBtn" class="export-btn" aria-label="Export current list">Export</button>
-                    </div>
                 </div>
             </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1396,6 +1396,17 @@ body.sidebar-resizing * {
     box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
 }
 
+.toolbar-btn-secondary {
+    background: #f5f5f5;
+    color: #333;
+    margin-right: 8px;
+}
+
+.toolbar-btn-secondary:hover {
+    background: #e8e8e8;
+    box-shadow: none;
+}
+
 .toolbar-spacer {
     flex: 1;
 }
@@ -2507,6 +2518,26 @@ body.sidebar-resizing * {
     padding: 6px 12px;
     font-size: 13px;
     border-radius: 8px;
+}
+
+[data-theme="glass"] .toolbar-btn-secondary,
+[data-theme="clear"] .toolbar-btn-secondary {
+    background: var(--ios-bg-secondary);
+    color: var(--ios-label);
+}
+
+[data-theme="dark"] .toolbar-btn-secondary {
+    background: var(--ios-bg-tertiary);
+    color: var(--ios-label);
+}
+
+[data-theme="glass"] .toolbar-btn-secondary:hover,
+[data-theme="clear"] .toolbar-btn-secondary:hover {
+    background: var(--ios-bg-tertiary);
+}
+
+[data-theme="dark"] .toolbar-btn-secondary:hover {
+    background: var(--ios-bg-secondary);
 }
 
 [data-theme="glass"] .toolbar-user-btn,


### PR DESCRIPTION
## Summary
- Moves the Export button to the toolbar, positioned left of the user menu
- Removes the bottom stats section (Total and Completed counts)
- Adds secondary button styling for the Export button

## Test plan
- [ ] Verify Export button appears in the toolbar next to the user menu
- [ ] Verify the bottom stats section is removed
- [ ] Click Export and verify it still works correctly
- [ ] Test with different themes (glass, dark, clear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)