### PR TITLE
UI: Move version number to sidebar under app name

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,10 @@
                             <circle cx="16" cy="16" r="14" fill="url(#sidebarIconGradient)"/>
                             <path d="M10 16.5L14 20.5L22 12.5" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
                         </svg>
-                        <span class="sidebar-app-title">TodoList</span>
+                        <div class="sidebar-app-info">
+                            <span class="sidebar-app-title">TodoList</span>
+                            <span class="sidebar-app-version" id="versionNumber">0.0.0</span>
+                        </div>
                     </div>
 
                     <!-- GTD Section -->
@@ -174,9 +177,6 @@
 
 
             <footer class="app-footer">
-                <div class="app-version" id="appVersion">
-                    Version <span id="versionNumber">0.0.0</span>
-                </div>
                 <div class="theme-selector">
                     <label for="themeSelect">Theme:</label>
                     <select id="themeSelect" aria-label="Color scheme selector">

--- a/styles.css
+++ b/styles.css
@@ -636,11 +636,24 @@ body.fullscreen-mode .todo-list {
     flex-shrink: 0;
 }
 
+.sidebar-app-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
 .sidebar-app-title {
     font-size: 18px;
     font-weight: 600;
     color: #333;
     letter-spacing: -0.3px;
+    line-height: 1.2;
+}
+
+.sidebar-app-version {
+    font-size: 11px;
+    color: #888;
+    letter-spacing: 0;
 }
 
 /* Sidebar resize handle */
@@ -2781,6 +2794,12 @@ body.sidebar-resizing * {
 [data-theme="dark"] .sidebar-app-title,
 [data-theme="clear"] .sidebar-app-title {
     color: var(--ios-label);
+}
+
+[data-theme="glass"] .sidebar-app-version,
+[data-theme="dark"] .sidebar-app-version,
+[data-theme="clear"] .sidebar-app-version {
+    color: var(--ios-label-tertiary);
 }
 
 [data-theme="glass"] .sidebar-section-header,


### PR DESCRIPTION
## Summary
- Moves the version number from the footer to the sidebar branding area
- Version is now displayed under the "TodoList" app name
- Removes version from the footer

## Test plan
- [ ] Verify version number appears under the TodoList name in the sidebar
- [ ] Verify version is no longer in the footer
- [ ] Test with different themes (glass, dark, clear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)