### PR TITLE
Remove categories and contexts sections, expand projects by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,9 +83,9 @@
                         <ul id="gtdList" class="gtd-list"></ul>
                     </div>
 
-                    <!-- Projects Section (collapsed by default) -->
-                    <div class="sidebar-section collapsed" id="projectsSection">
-                        <div class="sidebar-section-header" role="button" aria-expanded="false" aria-controls="projectsContent">
+                    <!-- Projects Section (expanded by default) -->
+                    <div class="sidebar-section" id="projectsSection">
+                        <div class="sidebar-section-header" role="button" aria-expanded="true" aria-controls="projectsContent">
                             <h2>Projects</h2>
                             <span class="sidebar-section-toggle" aria-hidden="true">▼</span>
                         </div>
@@ -104,47 +104,6 @@
                         </div>
                     </div>
 
-                    <!-- Categories Section (collapsed by default) -->
-                    <div class="sidebar-section collapsed" id="categoriesSection">
-                        <div class="sidebar-section-header" role="button" aria-expanded="false" aria-controls="categoriesContent">
-                            <h2>Categories</h2>
-                            <span class="sidebar-section-toggle" aria-hidden="true">▼</span>
-                        </div>
-                        <div class="sidebar-section-content" id="categoriesContent">
-                            <ul id="categoryList" class="category-list"></ul>
-                            <div class="add-category-form">
-                                <input
-                                    type="text"
-                                    id="newCategoryInput"
-                                    class="add-category-input"
-                                    placeholder="New category..."
-                                    autocomplete="off"
-                                >
-                                <button id="addCategoryBtn" class="add-category-btn">Add Category</button>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Contexts Section (collapsed by default) -->
-                    <div class="sidebar-section collapsed" id="contextsSection">
-                        <div class="sidebar-section-header" role="button" aria-expanded="false" aria-controls="contextsContent">
-                            <h2 class="contexts-header">Contexts</h2>
-                            <span class="sidebar-section-toggle" aria-hidden="true">▼</span>
-                        </div>
-                        <div class="sidebar-section-content" id="contextsContent">
-                            <ul id="contextList" class="context-list"></ul>
-                            <div class="add-context-form">
-                                <input
-                                    type="text"
-                                    id="newContextInput"
-                                    class="add-context-input"
-                                    placeholder="@context..."
-                                    autocomplete="off"
-                                >
-                                <button id="addContextBtn" class="add-context-btn">Add Context</button>
-                            </div>
-                        </div>
-                    </div>
                 </div>
 
                 <!-- Resize handle for sidebar -->

--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -88,6 +88,8 @@ const DYNAMIC_CLASS_PATTERNS = [
     /^body\.sidebar-resizing/,
     // Toolbar menu open state
     /\.toolbar-user-menu\.open/,
+    // Sidebar section collapsed state (toggled by JavaScript)
+    /\.sidebar-section\.collapsed/,
     // GTD status classes
     /\.inbox/,
     /\.next_action/,

--- a/styles.css
+++ b/styles.css
@@ -626,107 +626,6 @@ body.sidebar-resizing * {
     margin-top: 0;
 }
 
-.category-list {
-    list-style: none;
-}
-
-.category-item {
-    padding: 10px 12px;
-    margin-bottom: 5px;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-size: 14px;
-}
-
-.category-item:hover {
-    background: #f8f9fa;
-}
-
-.category-item.active {
-    background: linear-gradient(135deg, var(--primary-start) 0%, var(--primary-end) 100%);
-    color: white;
-    font-weight: 600;
-}
-
-.category-name {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.category-color {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    display: inline-block;
-}
-
-.category-delete {
-    opacity: 0;
-    background: none;
-    border: none;
-    color: inherit;
-    cursor: pointer;
-    padding: 2px 5px;
-    font-size: 16px;
-    transition: opacity 0.2s;
-}
-
-.category-item:hover .category-delete {
-    opacity: 0.7;
-}
-
-.category-delete:hover {
-    opacity: 1 !important;
-}
-
-.add-category-form {
-    margin-top: 15px;
-    padding-top: 15px;
-    border-top: 1px solid #e0e0e0;
-}
-
-.add-category-input {
-    width: 100%;
-    padding: 8px 10px;
-    border: 2px solid #e0e0e0;
-    border-radius: 6px;
-    font-size: 13px;
-    margin-bottom: 8px;
-}
-
-.add-category-input:focus {
-    outline: none;
-    border-color: var(--accent-color);
-}
-
-.add-category-btn {
-    width: 100%;
-    padding: 8px;
-    background: var(--accent-color);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 13px;
-    font-weight: 600;
-    transition: background 0.2s;
-}
-
-.add-category-btn:hover {
-    background: var(--accent-hover);
-}
-
-.add-category-btn:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-}
-
 /* Projects Section */
 .project-list {
     list-style: none;
@@ -1048,8 +947,6 @@ body.sidebar-resizing * {
 
 
 /* Drop target styles */
-.category-item.drag-over,
-.context-item.drag-over,
 .gtd-item.drag-over,
 .project-item.drag-over {
     background: var(--accent-color) !important;
@@ -1908,102 +1805,6 @@ body.sidebar-resizing * {
     color: white;
 }
 
-/* Context Styles */
-
-/* Contexts section in sidebar */
-.contexts-header {
-    /* No special styling needed - sections have margin via .sidebar-section */
-}
-
-.context-list {
-    list-style: none;
-}
-
-.context-item {
-    padding: 10px 12px;
-    margin-bottom: 5px;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-size: 14px;
-}
-
-.context-item:hover {
-    background: #f8f9fa;
-}
-
-.context-item.active {
-    background: linear-gradient(135deg, var(--primary-start) 0%, var(--primary-end) 100%);
-    color: white;
-    font-weight: 600;
-}
-
-.context-name {
-    flex: 1;
-}
-
-.context-delete {
-    opacity: 0;
-    background: none;
-    border: none;
-    color: inherit;
-    cursor: pointer;
-    padding: 2px 5px;
-    font-size: 16px;
-    transition: opacity 0.2s;
-}
-
-.context-item:hover .context-delete {
-    opacity: 0.7;
-}
-
-.context-delete:hover {
-    opacity: 1 !important;
-}
-
-.add-context-form {
-    margin-top: 15px;
-}
-
-.add-context-input {
-    width: 100%;
-    padding: 8px 10px;
-    border: 2px solid #e0e0e0;
-    border-radius: 6px;
-    font-size: 13px;
-    margin-bottom: 8px;
-}
-
-.add-context-input:focus {
-    outline: none;
-    border-color: var(--accent-color);
-}
-
-.add-context-btn {
-    width: 100%;
-    padding: 8px;
-    background: var(--accent-color);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 13px;
-    font-weight: 600;
-    transition: background 0.2s;
-}
-
-.add-context-btn:hover {
-    background: var(--accent-hover);
-}
-
-.add-context-btn:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-}
-
 /* GTD Status Badge Colors */
 .todo-gtd-badge {
     padding: 4px 10px;
@@ -2623,98 +2424,6 @@ body.sidebar-resizing * {
     color: var(--ios-label-tertiary);
 }
 
-/* iOS Grouped List (Categories) */
-[data-theme="glass"] .category-list,
-[data-theme="dark"] .category-list,
-[data-theme="clear"] .category-list {
-    background: var(--ios-bg-secondary);
-    border-radius: 12px;
-    overflow: hidden;
-    border: 1px solid var(--ios-separator);
-}
-
-[data-theme="glass"] .category-item,
-[data-theme="dark"] .category-item,
-[data-theme="clear"] .category-item {
-    background: transparent;
-    border: none;
-    border-radius: 0;
-    color: var(--ios-label);
-    padding: 12px 16px;
-    margin-bottom: 0;
-    transition: background 0.15s ease;
-    border-bottom: 0.5px solid var(--ios-separator);
-}
-
-[data-theme="glass"] .category-item:last-child,
-[data-theme="dark"] .category-item:last-child,
-[data-theme="clear"] .category-item:last-child {
-    border-bottom: none;
-}
-
-[data-theme="glass"] .category-item:hover,
-[data-theme="dark"] .category-item:hover,
-[data-theme="clear"] .category-item:hover {
-    background: var(--ios-gray6);
-}
-
-[data-theme="glass"] .category-item.active,
-[data-theme="dark"] .category-item.active,
-[data-theme="clear"] .category-item.active {
-    background: rgba(0, 122, 255, 0.1);
-    color: var(--ios-blue);
-    box-shadow: none;
-}
-
-[data-theme="glass"] .category-item.active .category-name,
-[data-theme="dark"] .category-item.active .category-name,
-[data-theme="clear"] .category-item.active .category-name {
-    font-weight: 600;
-}
-
-[data-theme="glass"] .add-category-form,
-[data-theme="dark"] .add-category-form,
-[data-theme="clear"] .add-category-form {
-    border-top: none;
-    padding: 20px 5px 0 5px; /* Horizontal padding for input focus outline */
-}
-
-[data-theme="glass"] .add-category-input,
-[data-theme="dark"] .add-category-input,
-[data-theme="clear"] .add-category-input {
-    background: var(--ios-bg-secondary);
-    border: 1px solid var(--ios-separator);
-    border-radius: 10px;
-    color: var(--ios-label);
-    font-size: 15px;
-}
-
-[data-theme="glass"] .add-category-input:focus,
-[data-theme="dark"] .add-category-input:focus,
-[data-theme="clear"] .add-category-input:focus {
-    background: var(--ios-bg-secondary);
-    border-color: var(--ios-blue);
-    outline: 4px solid rgba(0, 122, 255, 0.15);
-    outline-offset: -1px;
-}
-
-[data-theme="glass"] .add-category-btn,
-[data-theme="dark"] .add-category-btn,
-[data-theme="clear"] .add-category-btn {
-    background: var(--ios-blue);
-    color: #ffffff;
-    border: none;
-    border-radius: 10px;
-    font-weight: 600;
-    transition: background 0.15s ease;
-}
-
-[data-theme="glass"] .add-category-btn:hover,
-[data-theme="dark"] .add-category-btn:hover,
-[data-theme="clear"] .add-category-btn:hover {
-    background: var(--ios-blue-hover);
-}
-
 /* iOS Projects Section */
 [data-theme="glass"] .project-list,
 [data-theme="dark"] .project-list,
@@ -3210,14 +2919,6 @@ body.sidebar-resizing * {
     font-size: 14px;
 }
 
-/* iOS Category Colors */
-[data-theme="glass"] .category-color,
-[data-theme="dark"] .category-color,
-[data-theme="clear"] .category-color {
-    width: 10px;
-    height: 10px;
-}
-
 /* ========================================
    Glass Theme - GTD Elements
    ======================================== */
@@ -3294,60 +2995,7 @@ body.sidebar-resizing * {
     color: var(--ios-label-tertiary);
 }
 
-/* iOS Contexts Section */
-[data-theme="glass"] .contexts-header,
-[data-theme="dark"] .contexts-header,
-[data-theme="clear"] .contexts-header {
-    color: var(--ios-label-secondary);
-}
-
-[data-theme="glass"] .context-list,
-[data-theme="dark"] .context-list,
-[data-theme="clear"] .context-list {
-    background: var(--ios-bg-secondary);
-    border-radius: 12px;
-    overflow: hidden;
-    border: 1px solid var(--ios-separator);
-}
-
-[data-theme="glass"] .context-item,
-[data-theme="dark"] .context-item,
-[data-theme="clear"] .context-item {
-    background: transparent;
-    border: none;
-    border-radius: 0;
-    color: var(--ios-label);
-    padding: 12px 16px;
-    margin-bottom: 0;
-    border-bottom: 0.5px solid var(--ios-separator);
-}
-
-[data-theme="glass"] .context-item:last-child,
-[data-theme="dark"] .context-item:last-child,
-[data-theme="clear"] .context-item:last-child {
-    border-bottom: none;
-}
-
-[data-theme="glass"] .context-item:hover,
-[data-theme="dark"] .context-item:hover,
-[data-theme="clear"] .context-item:hover {
-    background: var(--ios-gray6);
-}
-
-[data-theme="glass"] .context-item.active,
-[data-theme="dark"] .context-item.active,
-[data-theme="clear"] .context-item.active {
-    background: rgba(0, 122, 255, 0.1);
-    color: var(--ios-blue);
-}
-
 /* Glass theme drag-over states */
-[data-theme="glass"] .category-item.drag-over,
-[data-theme="dark"] .category-item.drag-over,
-[data-theme="clear"] .category-item.drag-over,
-[data-theme="glass"] .context-item.drag-over,
-[data-theme="dark"] .context-item.drag-over,
-[data-theme="clear"] .context-item.drag-over,
 [data-theme="glass"] .gtd-item.drag-over,
 [data-theme="dark"] .gtd-item.drag-over,
 [data-theme="clear"] .gtd-item.drag-over,
@@ -3358,46 +3006,6 @@ body.sidebar-resizing * {
     color: white !important;
     transform: scale(1.02);
     box-shadow: 0 2px 8px rgba(0, 122, 255, 0.3);
-}
-
-[data-theme="glass"] .add-context-form,
-[data-theme="dark"] .add-context-form,
-[data-theme="clear"] .add-context-form {
-    padding: 0 5px; /* Horizontal padding for input focus outline */
-}
-
-[data-theme="glass"] .add-context-input,
-[data-theme="dark"] .add-context-input,
-[data-theme="clear"] .add-context-input {
-    background: var(--ios-bg-secondary);
-    border: 1px solid var(--ios-separator);
-    border-radius: 10px;
-    color: var(--ios-label);
-    font-size: 15px;
-}
-
-[data-theme="glass"] .add-context-input:focus,
-[data-theme="dark"] .add-context-input:focus,
-[data-theme="clear"] .add-context-input:focus {
-    border-color: var(--ios-blue);
-    outline: 4px solid rgba(0, 122, 255, 0.15);
-    outline-offset: -1px;
-}
-
-[data-theme="glass"] .add-context-btn,
-[data-theme="dark"] .add-context-btn,
-[data-theme="clear"] .add-context-btn {
-    background: var(--ios-blue);
-    color: #ffffff;
-    border: none;
-    border-radius: 10px;
-    font-weight: 600;
-}
-
-[data-theme="glass"] .add-context-btn:hover,
-[data-theme="dark"] .add-context-btn:hover,
-[data-theme="clear"] .add-context-btn:hover {
-    background: var(--ios-blue-hover);
 }
 
 /* iOS GTD Badges */


### PR DESCRIPTION
## Summary
- Remove categories section from left sidebar
- Remove contexts section from left sidebar
- Make projects section expanded by default (removed collapsed class)
- Remove associated JavaScript methods and DOM references
- Categories and contexts still available in todo form dropdowns

## Test plan
- [ ] Verify sidebar only shows GTD list and Projects section
- [ ] Verify projects section is expanded on page load
- [ ] Verify todo form still has category and context dropdowns
- [ ] Test adding/editing todos with categories and contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)