### PR TITLE
Add keyboard shortcut 'n' to create new item

### DIFF
--- a/app.js
+++ b/app.js
@@ -295,6 +295,26 @@ class TodoApp {
             if (e.target === this.addTodoModal) this.closeModal()
         })
 
+        // Keyboard shortcut: 'n' to create new item
+        document.addEventListener('keydown', (e) => {
+            // Ignore if user is typing in an input field
+            const activeElement = document.activeElement
+            const isTyping = activeElement.tagName === 'INPUT' ||
+                           activeElement.tagName === 'TEXTAREA' ||
+                           activeElement.tagName === 'SELECT' ||
+                           activeElement.isContentEditable
+
+            // Ignore if any modal is open
+            const modalOpen = this.addTodoModal.classList.contains('active') ||
+                            this.unlockModal.classList.contains('active') ||
+                            this.settingsModal.classList.contains('active')
+
+            if (e.key === 'n' && !isTyping && !modalOpen && !e.ctrlKey && !e.metaKey && !e.altKey) {
+                e.preventDefault()
+                this.openModal()
+            }
+        })
+
         // Add/Edit todo via modal form
         this.addTodoForm.addEventListener('submit', (e) => {
             e.preventDefault()


### PR DESCRIPTION
## Summary
- Press 'n' key to open the add todo modal
- Only works when not typing in an input field
- Disabled when any modal is already open
- Ignores key combinations with Ctrl/Meta/Alt

## Test plan
- [ ] Press 'n' while viewing todo list - modal should open
- [ ] Press 'n' while typing in project input - nothing should happen
- [ ] Press 'n' while modal is open - nothing should happen
- [ ] Press Ctrl+n or Cmd+n - should not trigger (allows browser shortcuts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)