### PR TITLE
Add Ctrl+Enter to submit todo form

### DIFF
--- a/app.js
+++ b/app.js
@@ -325,6 +325,18 @@ class TodoApp {
             }
         })
 
+        // Ctrl+Enter to submit todo form
+        this.addTodoForm.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                e.preventDefault()
+                if (this.editingTodoId) {
+                    this.updateTodo()
+                } else {
+                    this.addTodo()
+                }
+            }
+        })
+
         // Sync due date and scheduled status
         this.modalDueDateInput.addEventListener('change', () => {
             if (this.modalDueDateInput.value) {


### PR DESCRIPTION
## Summary
- Pressing Ctrl+Enter (or Cmd+Enter on Mac) submits the add/edit todo form
- Works from any field within the modal form

## Test plan
- [ ] Open add todo modal and press Ctrl+Enter - todo should be added
- [ ] Open edit todo modal and press Ctrl+Enter - todo should be updated
- [ ] Verify Cmd+Enter works on Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)