### PR TITLE
fix: 'n' keyboard shortcut not working in Firefox on Linux

### DIFF
--- a/app.js
+++ b/app.js
@@ -325,9 +325,10 @@ class TodoApp {
             // Ignore if any modal is open
             const modalOpen = this.addTodoModal.classList.contains('active') ||
                             this.unlockModal.classList.contains('active') ||
-                            this.settingsModal.classList.contains('active')
+                            this.settingsModal.classList.contains('active') ||
+                            this.manageAreasModal.classList.contains('active')
 
-            if (e.key === 'n' && !isTyping && !modalOpen && !e.ctrlKey && !e.metaKey && !e.altKey) {
+            if (e.code === 'KeyN' && !isTyping && !modalOpen && !e.ctrlKey && !e.metaKey && !e.altKey && !e.isComposing) {
                 e.preventDefault()
                 this.openModal()
             }


### PR DESCRIPTION
## Summary
- Fixed 'n' keyboard shortcut not working in Firefox on Linux by using `e.code` instead of `e.key`
- Added `e.isComposing` check to ignore events during IME composition
- Included `manageAreasModal` in the modal open check (was previously missing)

## Root Cause
Firefox on Linux with certain input methods (IME) like IBus or Fcitx can cause `e.key` to be unreliable or undefined. Using `e.code` instead checks the physical key pressed (`KeyN`), which works consistently across platforms and keyboard layouts.

## Test plan
- [ ] Test 'n' shortcut opens the add todo modal in Firefox on Linux
- [ ] Test 'n' shortcut still works in Chrome, Safari, and Edge
- [ ] Verify shortcut is blocked when any modal is open
- [ ] Verify shortcut is blocked when typing in input fields

🤖 Generated with [Claude Code](https://claude.ai/code)