### PR TITLE
feat: Add keyboard navigation for GTD views (fixes #162)

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,6 +414,49 @@
                 </form>
             </div>
         </div>
+
+        <!-- Keyboard Shortcuts Help Modal -->
+        <div id="keyboardShortcutsModal" class="modal-overlay">
+            <div class="modal keyboard-shortcuts-modal" role="dialog" aria-modal="true" aria-labelledby="keyboardShortcutsModalTitle">
+                <div class="modal-header">
+                    <h2 id="keyboardShortcutsModalTitle">Keyboard Shortcuts</h2>
+                    <button id="closeKeyboardShortcutsModal" class="modal-close" aria-label="Close modal">&times;</button>
+                </div>
+                <div class="keyboard-shortcuts-content">
+                    <div class="shortcuts-section">
+                        <h3>GTD Views</h3>
+                        <ul class="shortcuts-list">
+                            <li><kbd>1</kbd> <span>Inbox</span></li>
+                            <li><kbd>2</kbd> <span>Next</span></li>
+                            <li><kbd>3</kbd> <span>Scheduled</span></li>
+                            <li><kbd>4</kbd> <span>Waiting</span></li>
+                            <li><kbd>5</kbd> <span>Someday</span></li>
+                            <li><kbd>6</kbd> <span>Done</span></li>
+                            <li><kbd>0</kbd> <span>All</span></li>
+                        </ul>
+                    </div>
+                    <div class="shortcuts-section">
+                        <h3>Areas</h3>
+                        <ul class="shortcuts-list">
+                            <li><kbd>Shift</kbd> + <kbd>0</kbd> <span>All Areas</span></li>
+                            <li><kbd>Shift</kbd> + <kbd>1-9</kbd> <span>Switch to Area</span></li>
+                        </ul>
+                    </div>
+                    <div class="shortcuts-section">
+                        <h3>Actions</h3>
+                        <ul class="shortcuts-list">
+                            <li><kbd>n</kbd> <span>New Todo</span></li>
+                            <li><kbd>/</kbd> <span>Focus Search</span></li>
+                            <li><kbd>Esc</kbd> <span>Close Modal / Clear Search</span></li>
+                            <li><kbd>?</kbd> <span>Show This Help</span></li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="modal-actions">
+                    <button type="button" id="closeKeyboardShortcutsModalBtn" class="modal-btn modal-btn-secondary">Close</button>
+                </div>
+            </div>
+        </div>
     </div>
 
 

--- a/styles.css
+++ b/styles.css
@@ -1560,6 +1560,61 @@ body.sidebar-resizing * {
     color: #333;
 }
 
+/* Keyboard Shortcuts Modal */
+.keyboard-shortcuts-modal {
+    max-width: 520px;
+}
+
+.keyboard-shortcuts-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 24px;
+    padding: 16px 0;
+}
+
+.shortcuts-section h3 {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #666;
+    margin: 0 0 12px 0;
+    font-weight: 600;
+}
+
+.shortcuts-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.shortcuts-list li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 0;
+    font-size: 13px;
+    color: #333;
+}
+
+.shortcuts-list kbd {
+    display: inline-block;
+    padding: 3px 7px;
+    font-size: 11px;
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Mono', 'Monaco', monospace;
+    background: #f5f5f5;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.08);
+    color: #333;
+    min-width: 20px;
+    text-align: center;
+}
+
+.shortcuts-list span {
+    flex: 1;
+    color: #666;
+}
+
 .modal-form {
     display: flex;
     flex-direction: column;
@@ -2028,6 +2083,20 @@ body.sidebar-resizing * {
 
 .gtd-item.active .gtd-count {
     color: rgba(255, 255, 255, 0.8);
+}
+
+.gtd-shortcut {
+    font-size: 11px;
+    color: #bbb;
+    margin-left: auto;
+    margin-right: 8px;
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif;
+    min-width: 14px;
+    text-align: center;
+}
+
+.gtd-item.active .gtd-shortcut {
+    color: rgba(255, 255, 255, 0.6);
 }
 
 .gtd-item.inbox .gtd-icon { color: #1976d2; }
@@ -3270,6 +3339,33 @@ body.sidebar-resizing * {
     color: var(--ios-label);
 }
 
+/* iOS Keyboard Shortcuts Modal */
+[data-theme="glass"] .shortcuts-section h3,
+[data-theme="dark"] .shortcuts-section h3,
+[data-theme="clear"] .shortcuts-section h3 {
+    color: var(--ios-label-tertiary);
+}
+
+[data-theme="glass"] .shortcuts-list li,
+[data-theme="dark"] .shortcuts-list li,
+[data-theme="clear"] .shortcuts-list li {
+    color: var(--ios-label);
+}
+
+[data-theme="glass"] .shortcuts-list span,
+[data-theme="dark"] .shortcuts-list span,
+[data-theme="clear"] .shortcuts-list span {
+    color: var(--ios-label-secondary);
+}
+
+[data-theme="glass"] .shortcuts-list kbd,
+[data-theme="dark"] .shortcuts-list kbd,
+[data-theme="clear"] .shortcuts-list kbd {
+    background: var(--ios-bg-tertiary);
+    border-color: var(--ios-separator);
+    color: var(--ios-label);
+}
+
 /* iOS Empty State */
 [data-theme="glass"] .empty-state,
 [data-theme="dark"] .empty-state,
@@ -3391,6 +3487,19 @@ body.sidebar-resizing * {
 [data-theme="dark"] .gtd-count,
 [data-theme="clear"] .gtd-count {
     color: var(--ios-label-tertiary);
+}
+
+[data-theme="glass"] .gtd-shortcut,
+[data-theme="dark"] .gtd-shortcut,
+[data-theme="clear"] .gtd-shortcut {
+    color: var(--ios-label-quaternary);
+}
+
+[data-theme="glass"] .gtd-item.active .gtd-shortcut,
+[data-theme="dark"] .gtd-item.active .gtd-shortcut,
+[data-theme="clear"] .gtd-item.active .gtd-shortcut {
+    color: var(--ios-blue);
+    opacity: 0.6;
 }
 
 /* Glass theme drag-over states */


### PR DESCRIPTION
## Summary
- Add number keys 0-6 for quick GTD view switching
- Add `/` shortcut to focus search input
- Add `?` shortcut to open keyboard shortcuts help modal
- Display shortcut hints next to GTD menu items in the sidebar

## Problem
Users had no keyboard shortcuts to navigate between GTD views (Inbox, Next, Scheduled, Waiting, Someday, Done, All). This required mouse clicks for navigation, which slowed down workflow for keyboard-focused users.

## Solution
Implemented Option A from the issue: Plain number keys for GTD views:
| Key | View |
|-----|------|
| `1` | Inbox |
| `2` | Next |
| `3` | Scheduled |
| `4` | Waiting |
| `5` | Someday |
| `6` | Done |
| `0` | All |

Additional shortcuts:
| Key | Action |
|-----|--------|
| `/` | Focus search input |
| `?` | Show keyboard shortcuts help modal |

## Changes
- **app.js**: Added `selectGtdStatusByShortcut()` method and keyboard event handlers for 0-9 keys, `/`, and `?`
- **app.js**: Added `getGtdShortcut()` helper to map statuses to shortcut keys
- **app.js**: Added `openKeyboardShortcutsModal()` and `closeKeyboardShortcutsModal()` methods
- **app.js**: Updated `renderGtdList()` to display shortcut hints
- **index.html**: Added keyboard shortcuts help modal with all available shortcuts
- **styles.css**: Added `.gtd-shortcut` styling and keyboard shortcuts modal styles with theme support

## Testing
- [x] Number keys 0-6 switch GTD views correctly
- [x] `/` focuses search input
- [x] `?` opens keyboard shortcuts help modal
- [x] Shortcuts are disabled when typing in input fields
- [x] Shortcuts are disabled when modals are open
- [x] No conflicts with existing Shift+0-9 area shortcuts
- [x] JavaScript syntax validation passes

## Related Issues
- #159 - Quick switching of Areas with keyboard shortcuts (Shift+0-9) - now complemented by this PR

Fixes #162

Generated with [Claude Code](https://claude.com/claude-code)