### PR TITLE
fix: Add .gtd-shortcut to dynamic CSS selector ignore list

### DIFF
--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -146,6 +146,7 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.gtd-icon/,
     /\.gtd-label/,
     /\.gtd-count/,
+    /\.gtd-shortcut/,
     // Scheduled view headers (rendered by JavaScript)
     /\.scheduled-section-header/,
     /\.section-header-text/,


### PR DESCRIPTION
## Summary
Fixes the CSS selector check CI failure introduced in #164.

## Problem
The CSS selector validator was failing because `.gtd-shortcut` is rendered dynamically by JavaScript in `renderGtdList()`, not present in static HTML.

## Solution
Added `/\.gtd-shortcut/` to the `DYNAMIC_ELEMENT_SELECTORS` list in `scripts/check-css-selectors.js`.

## Changes
- `scripts/check-css-selectors.js` - Added `.gtd-shortcut` pattern to the GTD list items section

Generated with [Claude Code](https://claude.com/claude-code)