### PR TITLE
feat: Add Escape key to unfocus text inputs (fixes #166)

### DIFF
--- a/app.js
+++ b/app.js
@@ -372,6 +372,12 @@ class TodoApp {
                 e.preventDefault()
                 this.openKeyboardShortcutsModal()
             }
+
+            // Escape to unfocus text inputs (only when no modal is open)
+            if (e.key === 'Escape' && isTyping && !modalOpen) {
+                e.preventDefault()
+                document.activeElement.blur()
+            }
         })
 
         // Add/Edit todo via modal form


### PR DESCRIPTION
## Summary
- Added Escape key handler to blur text inputs when no modal is open
- Allows users to quickly exit input focus and use keyboard shortcuts

## Problem
When focus is in a text input field, keyboard shortcuts (0-6 for GTD views, Shift+0-9 for areas, etc.) don't work. Users must click elsewhere to unfocus the input before shortcuts work again.

## Solution
Added a new keyboard event handler that detects when:
1. User presses Escape
2. Focus is on a text input (INPUT, TEXTAREA, SELECT, or contentEditable)
3. No modal is currently open

When all conditions are met, the active element is blurred, restoring keyboard shortcut functionality.

## Changes
- Added Escape key handler in `app.js` (lines 376-380)
- Reuses existing `isTyping` and `modalOpen` checks for consistency

## Testing
- [x] JavaScript syntax validated (`node --check app.js`)
- [x] Modal Escape handling remains unaffected (checked via code review)
- [x] Follows existing keyboard shortcut patterns in the codebase

Fixes #166

Generated with [Claude Code](https://claude.com/claude-code)