### PR TITLE
Fix sidebar counts not refreshing after todo deletion (fixes #168)

### DIFF
--- a/app.js
+++ b/app.js
@@ -2055,6 +2055,7 @@ class TodoApp {
         }
 
         this.todos = this.todos.filter(t => t.id !== id)
+        this.renderGtdList()
         this.renderTodos()
     }
 


### PR DESCRIPTION
## Summary

Fixes sidebar GTD status counts not updating when a todo item is deleted.

## Problem

When deleting a todo item, the GTD status counts (Inbox, Next, Waiting, etc.) in the left sidebar menu did not refresh to reflect the updated totals. The counts remained stale until a page refresh or another action triggered a re-render.

## Solution

Added a call to `renderGtdList()` in the `deleteTodo()` method to re-render the GTD status list with updated counts after a todo is removed from the local state.

## Changes

- `app.js`: Added `this.renderGtdList()` call in `deleteTodo()` method (line 2058)

## Testing

- [x] Verified that counts update immediately when deleting a todo

Fixes #168

Generated with [Claude Code](https://claude.com/claude-code)