### PR TITLE
Add project todo counts in sidebar and comment field to MCP server

### DIFF
--- a/app.js
+++ b/app.js
@@ -1412,7 +1412,12 @@ class TodoApp {
         // Add "All Projects" option
         const allItem = document.createElement('li')
         allItem.className = `project-item ${this.selectedProjectId === null ? 'active' : ''}`
-        allItem.innerHTML = `<span class="project-name">All Projects</span>`
+        const totalCount = this.todos.filter(t => t.gtd_status !== 'done').length
+        const totalCountDisplay = totalCount > 0 ? totalCount : ''
+        allItem.innerHTML = `
+            <span class="project-name">All Projects</span>
+            <span class="project-count">${totalCountDisplay}</span>
+        `
         allItem.addEventListener('click', () => this.selectProject(null))
 
         // Drop target for removing project
@@ -1438,11 +1443,14 @@ class TodoApp {
         filteredProjects.forEach(project => {
             const li = document.createElement('li')
             li.className = `project-item ${this.selectedProjectId === project.id ? 'active' : ''}`
+            const count = this.getProjectTodoCount(project.id)
+            const countDisplay = count > 0 ? count : ''
             li.innerHTML = `
                 <span class="project-name">
                     <span class="project-color" style="background-color: ${this.validateColor(project.color)}"></span>
                     ${this.escapeHtml(project.name)}
                 </span>
+                <span class="project-count">${countDisplay}</span>
                 <button class="project-delete" data-id="${project.id}">×</button>
             `
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -164,6 +164,7 @@ const tools = [
       type: 'object',
       properties: {
         text: { type: 'string', description: 'Todo text content' },
+        comment: { type: 'string', description: 'Additional comment or description (optional)' },
         project_id: { type: 'string', description: 'Project ID (optional)' },
         category_id: { type: 'string', description: 'Category ID (optional)' },
         priority_id: { type: 'string', description: 'Priority ID (optional)' },
@@ -186,6 +187,7 @@ const tools = [
       properties: {
         id: { type: 'string', description: 'Todo ID' },
         text: { type: 'string', description: 'New todo text (optional)' },
+        comment: { type: 'string', description: 'Additional comment or description (optional, use null to remove)' },
         completed: { type: 'boolean', description: 'Completion status (optional)' },
         project_id: { type: 'string', description: 'Project ID (optional, use null to remove)' },
         category_id: { type: 'string', description: 'Category ID (optional)' },
@@ -224,6 +226,7 @@ const tools = [
             type: 'object',
             properties: {
               text: { type: 'string', description: 'Todo text content' },
+              comment: { type: 'string', description: 'Additional comment or description (optional)' },
               project_id: { type: 'string', description: 'Project ID (optional)' },
               gtd_status: { type: 'string', description: 'GTD status (default: inbox)' },
               due_date: { type: 'string', description: 'Due date (optional)' }
@@ -432,10 +435,12 @@ async function handleCreateTodo(args) {
   requireAuth();
 
   const encryptedText = await encrypt(args.text);
+  const encryptedComment = args.comment ? await encrypt(args.comment) : null;
 
   const todoData = {
     user_id: currentUser.id,
     text: encryptedText,
+    comment: encryptedComment,
     completed: false,
     gtd_status: args.gtd_status || 'inbox',
     project_id: args.project_id || null,
@@ -469,6 +474,9 @@ async function handleUpdateTodo(args) {
 
   if (args.text !== undefined) {
     updateData.text = await encrypt(args.text);
+  }
+  if (args.comment !== undefined) {
+    updateData.comment = args.comment ? await encrypt(args.comment) : null;
   }
   if (args.completed !== undefined) {
     updateData.completed = args.completed;
@@ -537,6 +545,7 @@ async function handleBatchCreateTodos(args) {
   const todosToInsert = await Promise.all(args.todos.map(async (todo) => ({
     user_id: currentUser.id,
     text: await encrypt(todo.text),
+    comment: todo.comment ? await encrypt(todo.comment) : null,
     completed: false,
     gtd_status: todo.gtd_status || 'inbox',
     project_id: todo.project_id || null,

--- a/styles.css
+++ b/styles.css
@@ -621,6 +621,18 @@ body.sidebar-resizing * {
     opacity: 1 !important;
 }
 
+.project-count {
+    font-size: 12px;
+    color: #999;
+    min-width: 20px;
+    text-align: right;
+    margin-right: 4px;
+}
+
+.project-item.active .project-count {
+    color: rgba(255, 255, 255, 0.8);
+}
+
 .add-project-form {
     margin-top: 15px;
     padding-top: 15px;
@@ -2973,6 +2985,18 @@ body.sidebar-resizing * {
 [data-theme="dark"] .project-item.active .project-name,
 [data-theme="clear"] .project-item.active .project-name {
     font-weight: 600;
+}
+
+[data-theme="glass"] .project-count,
+[data-theme="dark"] .project-count,
+[data-theme="clear"] .project-count {
+    color: var(--ios-secondary-label);
+}
+
+[data-theme="glass"] .project-item.active .project-count,
+[data-theme="dark"] .project-item.active .project-count,
+[data-theme="clear"] .project-item.active .project-count {
+    color: var(--ios-blue);
 }
 
 [data-theme="glass"] .add-project-form,


### PR DESCRIPTION
## Summary
- Display todo count next to each project in the left sidebar
- Add `comment` field support to `create_todo`, `update_todo`, and `batch_create_todos` MCP tools
- Comments are encrypted like other text fields for security

## Test plan
- [ ] Verify project counts appear in sidebar
- [ ] Verify counts update when todos are added/removed/completed
- [ ] Verify counts work across all themes (default, glass, dark, clear)
- [ ] Test MCP server comment field with create_todo
- [ ] Test MCP server comment field with batch_create_todos
- [ ] Test MCP server comment field with update_todo

🤖 Generated with [Claude Code](https://claude.com/claude-code)