### PR TITLE
fix: Add .project-count to CSS selector ignore list

### DIFF
--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -135,6 +135,7 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.project-item/,
     /\.project-name/,
     /\.project-color/,
+    /\.project-count/,
     /\.project-delete/,
     /\.project-card/,
     // Context items (rendered by JavaScript)


### PR DESCRIPTION
## Summary
- Add `.project-count` to the dynamic element selectors list in the CSS validator
- Fixes CI failure where the selector was flagged as broken

## Test plan
- [ ] CI check-selectors job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)