### PR TITLE
feat: Display project name above todo list when project is selected

### DIFF
--- a/app.js
+++ b/app.js
@@ -2283,6 +2283,17 @@ class TodoApp {
             return
         }
 
+        // Show project title header when a project is selected
+        if (this.selectedProjectId !== null) {
+            const project = this.projects.find(p => p.id === this.selectedProjectId)
+            if (project) {
+                const header = document.createElement('li')
+                header.className = 'project-title-header'
+                header.innerHTML = `<span class="project-title-text">${this.escapeHtml(project.name)}</span>`
+                this.todoList.appendChild(header)
+            }
+        }
+
         const filteredTodos = this.getFilteredTodos()
 
         if (filteredTodos.length === 0) {

--- a/styles.css
+++ b/styles.css
@@ -854,6 +854,21 @@ body.sidebar-resizing * {
     gap: 8px;
 }
 
+/* Project title header (shown when a project is selected) */
+.project-title-header {
+    padding: 16px 20px;
+    margin-bottom: 8px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, var(--primary-start) 0%, var(--primary-end) 100%);
+}
+
+.project-title-text {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: white;
+    letter-spacing: 0.3px;
+}
+
 .todo-item {
     background: #f8f9fa;
     padding: 15px;
@@ -3149,6 +3164,26 @@ body.sidebar-resizing * {
 [data-theme="clear"] .scheduled-section-header.later {
     background: var(--ios-gray5);
     color: var(--ios-label-secondary);
+}
+
+/* iOS Project Title Header */
+[data-theme="glass"] .project-title-header,
+[data-theme="dark"] .project-title-header,
+[data-theme="clear"] .project-title-header {
+    background: var(--ios-gray5);
+    border-radius: 0;
+    margin-bottom: 0;
+    padding: 12px 16px;
+    border-bottom: 0.5px solid var(--ios-separator);
+}
+
+[data-theme="glass"] .project-title-text,
+[data-theme="dark"] .project-title-text,
+[data-theme="clear"] .project-title-text {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--ios-label);
+    letter-spacing: 0.2px;
 }
 
 [data-theme="glass"] .todo-item,


### PR DESCRIPTION
## Summary
- Displays the project name as a header above the todo list when a project is selected from the sidebar
- Provides clear visual context for which project's items are being viewed
- Includes styling for both default and iOS-style themes (glass, dark, clear)

## Test plan
- [ ] Select a project from the sidebar and verify the project name appears above the todo list
- [ ] Switch between different projects and verify the header updates
- [ ] Select "All Projects" and verify no project header is shown (projects view is displayed instead)
- [ ] Test with different themes (Glass, Dark, Clear) to ensure styling is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)