### PR TITLE
fix: Show project title header for empty projects

### DIFF
--- a/src/ui/TodoList.js
+++ b/src/ui/TodoList.js
@@ -85,7 +85,9 @@ export function renderTodos(container, options = {}) {
     if (filteredTodos.length === 0) {
         // Special zen state for empty Inbox
         if (state.selectedGtdStatus === 'inbox') {
-            container.innerHTML = `
+            const zenState = document.createElement('li')
+            zenState.className = 'inbox-zen-state-wrapper'
+            zenState.innerHTML = `
                 <div class="inbox-zen-state">
                     <svg class="zen-illustration" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <!-- Calm water ripples -->
@@ -121,6 +123,7 @@ export function renderTodos(container, options = {}) {
                     <p class="zen-message">Your mind is clear. All items have been processed. Take a moment to breathe.</p>
                 </div>
             `
+            container.appendChild(zenState)
         } else {
             let emptyMsg
             if (state.searchQuery) {
@@ -130,7 +133,10 @@ export function renderTodos(container, options = {}) {
             } else {
                 emptyMsg = 'No todos in selected categories.'
             }
-            container.innerHTML = `<div class="empty-state">${emptyMsg}</div>`
+            const emptyState = document.createElement('li')
+            emptyState.className = 'empty-state-wrapper'
+            emptyState.innerHTML = `<div class="empty-state">${emptyMsg}</div>`
+            container.appendChild(emptyState)
         }
         return
     }


### PR DESCRIPTION
## Summary
- Fixed project title header not appearing for empty projects
- Changed empty state rendering to use `appendChild` instead of `innerHTML` assignment
- Preserves the project header when displaying empty state messages

## Test plan
- [ ] Select a project that has todos, verify title header appears
- [ ] Select a project that has no todos, verify title header still appears above the empty state message
- [ ] Test inbox zen state still works correctly
- [ ] Test search with no results still shows empty state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)