### PR TITLE
fix: Exit projects view when selecting GTD status

### DIFF
--- a/src/ui/GtdList.js
+++ b/src/ui/GtdList.js
@@ -44,6 +44,8 @@ export function getGtdShortcut(status) {
  */
 export function selectGtdStatus(status) {
     store.set('selectedGtdStatus', status)
+    // Exit projects view when selecting a GTD status
+    store.set('showProjectsView', false)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed bug where selecting GTD status (Scheduled, Waiting, Done, etc.) while in "All Projects" view still showed the projects list instead of todos
- Added `store.set('showProjectsView', false)` when selecting a GTD status

## Test plan
- [ ] Click "All Projects" in sidebar (shows project cards)
- [ ] Click on "Scheduled" in GTD list - should now show scheduled todos, not project cards
- [ ] Click on "Done" - should show completed todos
- [ ] Click on any other GTD status - should show filtered todos
- [ ] Verify normal project selection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)