### PR TITLE
fix: Pin Supabase CDN version to 2.47.0

### DIFF
--- a/src/core/supabase.js
+++ b/src/core/supabase.js
@@ -1,4 +1,4 @@
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm'
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.47.0/+esm'
 
 // Initialize Supabase
 const supabaseUrl = 'https://rkvmujdayjmszmyzbhal.supabase.co'


### PR DESCRIPTION
## Summary

- Pin `@supabase/supabase-js` CDN import to version `2.47.0` instead of floating `@2`
- Fixes production outage caused by broken Supabase 2.48.0+ CDN bundle

## Root Cause

The jsDelivr CDN fails to bundle Supabase 2.48.0+ because it introduced Node.js-specific imports (`node:module`) that Rollup cannot handle for browser bundling.

## Test plan

- [ ] Verify https://radekcap.github.io/todolist/ loads after deployment
- [ ] Confirm login/logout works
- [ ] Verify todos can be created and viewed

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)