### PR TITLE
fix: Update areas dropdown when changing area via keyboard shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -142,7 +142,11 @@ class TodoApp {
         // Subscribe to store changes and re-render
         store.subscribe('selectedGtdStatus', () => this.render())
         store.subscribe('selectedProjectId', () => this.render())
-        store.subscribe('selectedAreaId', () => this.render())
+        store.subscribe('selectedAreaId', () => {
+            renderAreasDropdown(this.areaListContainer, this.toolbarAreasDropdown, this.areaListDivider)
+            updateAreasLabel(this.toolbarAreasLabel)
+            this.render()
+        })
         store.subscribe('showProjectsView', () => this.render())
         store.subscribe('todos', () => this.renderAll())
         store.subscribe('projects', () => {


### PR DESCRIPTION
## Summary

- Fix areas dropdown not updating when switching areas with keyboard shortcuts (Shift+0-9)

## Problem

When using keyboard shortcuts to change the selected area, the dropdown button still showed "All Areas" and the active state in the dropdown menu didn't update.

## Solution

The `selectedAreaId` store subscription was only calling `render()`, which updates the todo list and area header but not the dropdown UI. Added calls to `renderAreasDropdown()` and `updateAreasLabel()` so the dropdown syncs when the selection changes.

## Test plan

- [ ] Press Shift+1 to select first area - dropdown should show area name
- [ ] Press Shift+0 to go back to All Areas - dropdown should show "All Areas"
- [ ] Open dropdown - correct item should be highlighted as active

🤖 Generated with [Claude Code](https://claude.com/claude-code)