### PR TITLE
fix: Add spacing between area color dot and text

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1385,6 +1385,7 @@ body.sidebar-resizing * {
     border-radius: 50%;
     display: inline-block;
     flex-shrink: 0;
+    margin-right: 6px;
 }
 
 .areas-item-label {


### PR DESCRIPTION
## Summary

Fix color dot overlapping with area name text in the dropdown menu.

## Problem

The area color dot was too close to the text, causing visual overlap.

## Solution

Added `margin-right: 6px` to `.area-color-dot` for proper spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)