### PR TITLE
fix: Add dynamic selectors to CSS check ignore list

### DIFF
--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -162,6 +162,12 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.manage-areas-actions/,
     /\.manage-areas-edit/,
     /\.manage-areas-delete/,
+    /\.manage-areas-color/,
+    // Area color indicators (rendered by JavaScript)
+    /\.area-color-dot/,
+    // Project title header (rendered by JavaScript)
+    /\.project-title-header/,
+    /\.project-title-text/,
     // Area shortcut hints (rendered by JavaScript for dynamic areas)
     /\.areas-item-shortcut/,
     // Empty/loading states (rendered by JavaScript)


### PR DESCRIPTION
## Summary

Fix the CSS Selector Check workflow by adding dynamically-generated selectors to the ignore list.

## Problem

The workflow was failing because these selectors are generated by JavaScript and don't exist in static HTML:
- `.manage-areas-color` - color picker input
- `.area-color-dot` - area color indicators
- `.project-title-header` / `.project-title-text` - project header

## Solution

Added these patterns to `DYNAMIC_ELEMENT_SELECTORS` in `scripts/check-css-selectors.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)