### PR TITLE
feat: Add bulk import for adding multiple todos at once

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ import { renderProjects, updateProjectSelect } from './src/ui/ProjectList.js'
 import { renderGtdList, selectGtdStatus, selectGtdStatusByShortcut } from './src/ui/GtdList.js'
 import { renderAreasDropdown, updateAreasLabel, updateAreaHeader, renderManageAreasList } from './src/ui/AreasDropdown.js'
 import { TodoModal } from './src/ui/modals/TodoModal.js'
+import { ImportModal } from './src/ui/modals/ImportModal.js'
 
 // Application version
 const APP_VERSION = '2.0.8'
@@ -124,6 +125,23 @@ class TodoApp {
 
         // Set callback for when modal closes
         this.todoModal.onClose = () => this.render()
+
+        // Initialize ImportModal
+        this.importModal = new ImportModal({
+            modal: document.getElementById('importModal'),
+            form: document.getElementById('importForm'),
+            textarea: document.getElementById('importTextarea'),
+            projectSelect: document.getElementById('importProjectSelect'),
+            categorySelect: document.getElementById('importCategorySelect'),
+            contextSelect: document.getElementById('importContextSelect'),
+            prioritySelect: document.getElementById('importPrioritySelect'),
+            gtdStatusSelect: document.getElementById('importGtdStatusSelect'),
+            dueDateInput: document.getElementById('importDueDateInput'),
+            importBtn: document.getElementById('importBtn'),
+            closeBtn: document.getElementById('closeImportModal'),
+            cancelBtn: document.getElementById('cancelImportModal'),
+            openBtn: document.getElementById('openImportModal')
+        })
 
         this.initAuth()
         this.initEventListeners()

--- a/index.html
+++ b/index.html
@@ -142,6 +142,7 @@
                             </div>
                         </div>
                         <button id="openAddTodoModal" class="toolbar-btn add-todo-btn">+ Add Todo</button>
+                        <button id="openImportModal" class="toolbar-btn toolbar-btn-secondary">Import</button>
                         <div class="toolbar-search">
                             <input
                                 type="text"
@@ -312,6 +313,124 @@
                             <select id="modalContextSelect" class="modal-sidebar-select" aria-label="Context">
                                 <option value="">No Context</option>
                             </select>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <!-- Import Modal -->
+        <div id="importModal" class="modal-overlay">
+            <div class="modal modal-wide" role="dialog" aria-modal="true" aria-labelledby="importModalTitle">
+                <div class="modal-header">
+                    <h2 id="importModalTitle">Import Todos</h2>
+                    <button id="closeImportModal" class="modal-close" aria-label="Close modal">&times;</button>
+                </div>
+                <form id="importForm" class="modal-form modal-form-split">
+                    <div class="modal-form-main">
+                        <div class="modal-field">
+                            <label for="importTextarea" class="import-label">
+                                Paste your todos below (one per line)
+                            </label>
+                            <textarea
+                                id="importTextarea"
+                                class="import-textarea"
+                                placeholder="Buy groceries&#10;Call dentist&#10;Review project proposal&#10;Send invoice"
+                                rows="12"
+                                required
+                            ></textarea>
+                            <small class="import-hint">Empty lines will be ignored. Each line becomes a separate todo.</small>
+                        </div>
+                        <div class="modal-actions">
+                            <button type="submit" id="importBtn" class="modal-btn modal-btn-primary">Import Todos</button>
+                            <button type="button" id="cancelImportModal" class="modal-btn modal-btn-secondary">Cancel</button>
+                        </div>
+                    </div>
+                    <div class="modal-form-sidebar">
+                        <p class="import-sidebar-title">Apply to all imported items:</p>
+                        <div class="modal-sidebar-field">
+                            <label for="importGtdStatusSelect">
+                                <span class="modal-field-icon">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+                                    </svg>
+                                </span>
+                                <span class="modal-field-label">status</span>
+                            </label>
+                            <select id="importGtdStatusSelect" class="modal-sidebar-select" aria-label="GTD Status">
+                                <option value="inbox">Inbox</option>
+                                <option value="next_action">Next Action</option>
+                                <option value="scheduled">Scheduled</option>
+                                <option value="waiting_for">Waiting For</option>
+                                <option value="someday_maybe">Someday/Maybe</option>
+                            </select>
+                        </div>
+                        <div class="modal-sidebar-field">
+                            <label for="importProjectSelect">
+                                <span class="modal-field-icon">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+                                    </svg>
+                                </span>
+                                <span class="modal-field-label">project</span>
+                            </label>
+                            <select id="importProjectSelect" class="modal-sidebar-select">
+                                <option value="">No Project</option>
+                            </select>
+                        </div>
+                        <div class="modal-sidebar-field">
+                            <label for="importCategorySelect">
+                                <span class="modal-field-icon">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/>
+                                        <line x1="7" y1="7" x2="7.01" y2="7"/>
+                                    </svg>
+                                </span>
+                                <span class="modal-field-label">category</span>
+                            </label>
+                            <select id="importCategorySelect" class="modal-sidebar-select">
+                                <option value="">No Category</option>
+                            </select>
+                        </div>
+                        <div class="modal-sidebar-field">
+                            <label for="importContextSelect">
+                                <span class="modal-field-icon">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <circle cx="12" cy="10" r="3"/>
+                                        <path d="M12 21.7C17.3 17 20 13 20 10a8 8 0 1 0-16 0c0 3 2.7 7 8 11.7z"/>
+                                    </svg>
+                                </span>
+                                <span class="modal-field-label">context</span>
+                            </label>
+                            <select id="importContextSelect" class="modal-sidebar-select" aria-label="Context">
+                                <option value="">No Context</option>
+                            </select>
+                        </div>
+                        <div class="modal-sidebar-field">
+                            <label for="importPrioritySelect">
+                                <span class="modal-field-icon">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/>
+                                        <line x1="4" y1="22" x2="4" y2="15"/>
+                                    </svg>
+                                </span>
+                                <span class="modal-field-label">priority</span>
+                            </label>
+                            <select id="importPrioritySelect" class="modal-sidebar-select" aria-label="Priority">
+                                <option value="">No Priority</option>
+                            </select>
+                        </div>
+                        <div class="modal-sidebar-field">
+                            <label for="importDueDateInput">
+                                <span class="modal-field-icon">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M4 4h16a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/>
+                                        <path d="M16 2v4M8 2v4M2 10h20"/>
+                                    </svg>
+                                </span>
+                                <span class="modal-field-label">due date</span>
+                            </label>
+                            <input type="date" id="importDueDateInput" class="modal-sidebar-input">
                         </div>
                     </div>
                 </form>

--- a/src/ui/modals/ImportModal.js
+++ b/src/ui/modals/ImportModal.js
@@ -1,0 +1,217 @@
+import { store } from '../../core/store.js'
+import { addTodo } from '../../services/todos.js'
+
+/**
+ * ImportModal controller
+ * Manages the bulk import modal for adding multiple todos at once
+ */
+export class ImportModal {
+    constructor(elements) {
+        this.modal = elements.modal
+        this.form = elements.form
+        this.textarea = elements.textarea
+        this.projectSelect = elements.projectSelect
+        this.categorySelect = elements.categorySelect
+        this.contextSelect = elements.contextSelect
+        this.prioritySelect = elements.prioritySelect
+        this.gtdStatusSelect = elements.gtdStatusSelect
+        this.dueDateInput = elements.dueDateInput
+        this.importBtn = elements.importBtn
+        this.closeBtn = elements.closeBtn
+        this.cancelBtn = elements.cancelBtn
+        this.openBtn = elements.openBtn
+
+        this.handleEscapeKey = null
+
+        this.initEventListeners()
+    }
+
+    initEventListeners() {
+        // Modal controls
+        if (this.openBtn) {
+            this.openBtn.addEventListener('click', () => this.open())
+        }
+        this.closeBtn.addEventListener('click', () => this.close())
+        this.cancelBtn.addEventListener('click', () => this.close())
+        this.modal.addEventListener('click', (e) => {
+            if (e.target === this.modal) this.close()
+        })
+
+        // Form submission
+        this.form.addEventListener('submit', (e) => {
+            e.preventDefault()
+            this.submit()
+        })
+
+        // Ctrl+Enter to submit
+        this.form.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                e.preventDefault()
+                this.submit()
+            }
+        })
+    }
+
+    /**
+     * Open the import modal
+     */
+    open() {
+        this.modal.classList.add('active')
+        this.textarea.value = ''
+        this.dueDateInput.value = ''
+        this.gtdStatusSelect.value = 'inbox'
+        this.projectSelect.value = ''
+        this.categorySelect.value = ''
+        this.contextSelect.value = ''
+        this.prioritySelect.value = ''
+
+        const state = store.state
+
+        // Pre-select project if one is selected
+        if (state.selectedProjectId) {
+            this.projectSelect.value = state.selectedProjectId
+        }
+
+        // Pre-select GTD status based on current view
+        if (state.selectedGtdStatus && state.selectedGtdStatus !== 'all') {
+            this.gtdStatusSelect.value = state.selectedGtdStatus
+        }
+
+        // Update select options
+        this.updateProjectSelect()
+        this.updateCategorySelect()
+        this.updateContextSelect()
+        this.updatePrioritySelect()
+
+        // Add escape key listener
+        this.handleEscapeKey = (e) => {
+            if (e.key === 'Escape') this.close()
+        }
+        document.addEventListener('keydown', this.handleEscapeKey)
+
+        // Focus textarea
+        setTimeout(() => this.textarea.focus(), 50)
+    }
+
+    /**
+     * Close the import modal
+     */
+    close() {
+        this.modal.classList.remove('active')
+        if (this.handleEscapeKey) {
+            document.removeEventListener('keydown', this.handleEscapeKey)
+            this.handleEscapeKey = null
+        }
+    }
+
+    /**
+     * Submit the import form
+     */
+    async submit() {
+        const text = this.textarea.value.trim()
+        if (!text) return
+
+        // Parse lines - each non-empty line is a todo
+        const lines = text.split('\n')
+            .map(line => line.trim())
+            .filter(line => line.length > 0)
+
+        if (lines.length === 0) return
+
+        // Get shared settings
+        const projectId = this.projectSelect.value || null
+        const categoryId = this.categorySelect.value || null
+        const contextId = this.contextSelect.value || null
+        const priorityId = this.prioritySelect.value || null
+        const gtdStatus = this.gtdStatusSelect.value || 'inbox'
+        const dueDate = this.dueDateInput.value || null
+
+        // Disable button during import
+        this.importBtn.disabled = true
+        this.importBtn.textContent = `Importing ${lines.length} todos...`
+
+        try {
+            // Import each line as a todo
+            for (const line of lines) {
+                await addTodo({
+                    text: line,
+                    projectId,
+                    categoryId,
+                    contextId,
+                    priorityId,
+                    gtdStatus,
+                    dueDate,
+                    comment: null
+                })
+            }
+
+            this.close()
+        } catch (error) {
+            console.error('Error importing todos:', error)
+            alert(`Error importing todos: ${error.message}`)
+        } finally {
+            this.importBtn.disabled = false
+            this.importBtn.textContent = 'Import Todos'
+        }
+    }
+
+    /**
+     * Update project select options
+     */
+    updateProjectSelect() {
+        const projects = store.get('projects')
+        this.projectSelect.innerHTML = '<option value="">No Project</option>'
+
+        projects.forEach(project => {
+            const option = document.createElement('option')
+            option.value = project.id
+            option.textContent = project.name
+            this.projectSelect.appendChild(option)
+        })
+    }
+
+    /**
+     * Update category select options
+     */
+    updateCategorySelect() {
+        const categories = store.get('categories')
+        this.categorySelect.innerHTML = '<option value="">No Category</option>'
+
+        categories.forEach(category => {
+            const option = document.createElement('option')
+            option.value = category.id
+            option.textContent = category.name
+            this.categorySelect.appendChild(option)
+        })
+    }
+
+    /**
+     * Update context select options
+     */
+    updateContextSelect() {
+        const contexts = store.get('contexts')
+        this.contextSelect.innerHTML = '<option value="">No Context</option>'
+
+        contexts.forEach(context => {
+            const option = document.createElement('option')
+            option.value = context.id
+            option.textContent = context.name
+            this.contextSelect.appendChild(option)
+        })
+    }
+
+    /**
+     * Update priority select options
+     */
+    updatePrioritySelect() {
+        const priorities = store.get('priorities')
+        this.prioritySelect.innerHTML = '<option value="">No Priority</option>'
+
+        priorities.forEach(priority => {
+            const option = document.createElement('option')
+            option.value = priority.id
+            option.textContent = priority.name
+            this.prioritySelect.appendChild(option)
+        })
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -2000,6 +2000,56 @@ body.sidebar-resizing * {
     color: #aaa;
 }
 
+/* Import Modal Styles */
+.import-label {
+    font-size: 14px;
+    font-weight: 500;
+    color: #666;
+    margin-bottom: 8px;
+    display: block;
+}
+
+.import-textarea {
+    width: 100%;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    font-size: 14px;
+    padding: 12px;
+    font-family: inherit;
+    resize: vertical;
+    min-height: 200px;
+    background: #fafafa;
+    line-height: 1.6;
+}
+
+.import-textarea:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    background: white;
+}
+
+.import-textarea::placeholder {
+    color: #aaa;
+}
+
+.import-hint {
+    display: block;
+    font-size: 12px;
+    color: #999;
+    margin-top: 8px;
+}
+
+.import-sidebar-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin: 0 0 12px 0;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
 .modal-sidebar-field {
     display: flex;
     flex-direction: column;
@@ -2900,6 +2950,49 @@ body.sidebar-resizing * {
 [data-theme="dark"] .modal-notes-input::placeholder,
 [data-theme="clear"] .modal-notes-input::placeholder {
     color: var(--ios-label-tertiary);
+}
+
+/* Import Modal Theme Styles */
+[data-theme="glass"] .import-textarea,
+[data-theme="dark"] .import-textarea,
+[data-theme="clear"] .import-textarea {
+    background: var(--ios-bg-secondary);
+    border-color: var(--ios-separator);
+    border-radius: 10px;
+    color: var(--ios-label);
+}
+
+[data-theme="glass"] .import-textarea:focus,
+[data-theme="dark"] .import-textarea:focus,
+[data-theme="clear"] .import-textarea:focus {
+    border-color: var(--ios-blue);
+    background: var(--ios-bg-secondary);
+    box-shadow: 0 0 0 4px rgba(0, 122, 255, 0.15);
+}
+
+[data-theme="glass"] .import-textarea::placeholder,
+[data-theme="dark"] .import-textarea::placeholder,
+[data-theme="clear"] .import-textarea::placeholder {
+    color: var(--ios-label-tertiary);
+}
+
+[data-theme="glass"] .import-label,
+[data-theme="dark"] .import-label,
+[data-theme="clear"] .import-label {
+    color: var(--ios-label-secondary);
+}
+
+[data-theme="glass"] .import-hint,
+[data-theme="dark"] .import-hint,
+[data-theme="clear"] .import-hint {
+    color: var(--ios-label-tertiary);
+}
+
+[data-theme="glass"] .import-sidebar-title,
+[data-theme="dark"] .import-sidebar-title,
+[data-theme="clear"] .import-sidebar-title {
+    color: var(--ios-label-secondary);
+    border-bottom-color: var(--ios-separator);
 }
 
 [data-theme="glass"] .priority-star,


### PR DESCRIPTION
## Summary

- Add "Import" button to toolbar for bulk importing todos
- Each line in the textarea becomes a separate todo
- Common settings apply to all imported items

## Problem

Adding multiple related todos one-by-one is tedious, especially when they share the same project, category, or status.

## Solution

New Import modal that allows pasting multiple lines of text where:
- Each non-empty line becomes a separate todo
- Shared settings (project, category, context, priority, GTD status, due date) apply to all items

## Changes

- `index.html` - Added Import button and Import modal HTML
- `app.js` - Import and initialize ImportModal
- `src/ui/modals/ImportModal.js` - New modal controller class
- `styles.css` - Styles for import textarea and labels

## Usage

1. Click "Import" button in toolbar
2. Paste or type todos (one per line)
3. Optionally set common project, category, status, etc.
4. Click "Import Todos"

## Test plan

- [ ] Click Import button opens modal
- [ ] Paste multiple lines and import
- [ ] Verify all todos created with shared settings
- [ ] Verify empty lines are ignored
- [ ] Ctrl+Enter submits form
- [ ] Escape closes modal

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)