### PR TITLE
fix: Anchor modal position to prevent shifting during import

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1594,8 +1594,10 @@ body.sidebar-resizing * {
     bottom: 0;
     background: rgba(0, 0, 0, 0.5);
     z-index: 1000;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
+    padding-top: 5vh;
+    overflow-y: auto;
 }
 
 .modal-overlay.active {


### PR DESCRIPTION
## Summary

Fix modal position shifting down as todos are imported.

## Problem

The import modal was moving down with each imported todo because it used `align-items: center` for vertical centering. As the todo list behind the modal grew, the centering recalculated and shifted the modal.

## Solution

Changed modal overlay from `align-items: center` to `align-items: flex-start` with `padding-top: 5vh`. This anchors the modal at a fixed distance from the top, preventing any movement during import operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)