### PR TITLE
fix: Prevent todo list shift when deleting items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -260,6 +260,7 @@ body {
 body.fullscreen-mode {
     padding: 0;
     align-items: stretch;
+    scrollbar-gutter: stable;
 }
 
 body.fullscreen-mode .container {
@@ -720,6 +721,7 @@ body.sidebar-resizing * {
 .content {
     flex: 1;
     min-width: 0;
+    scrollbar-gutter: stable;
 }
 
 /* Area Header - Shows current area with color indicator */


### PR DESCRIPTION
## Summary

Fix the visual shift when deleting todos from the list.

## Problem

When a todo was deleted, the list would visually shift slightly left then right. This was caused by the scrollbar appearing/disappearing as content changed, affecting the layout width.

## Solution

Added `scrollbar-gutter: stable` to:
- `body.fullscreen-mode` 
- `.content`

This reserves space for the scrollbar even when it's not visible, preventing layout shifts when content changes.

## Test plan

- [ ] Delete a todo - list should not shift horizontally
- [ ] Add todos until scrollbar appears - no shift
- [ ] Remove todos until scrollbar disappears - no shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)