### PR TITLE
fix: Remove horizontal shift from todo list re-render

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -912,11 +912,9 @@ body.sidebar-resizing * {
 @keyframes slideIn {
     from {
         opacity: 0;
-        transform: translateX(-20px);
     }
     to {
         opacity: 1;
-        transform: translateX(0);
     }
 }
 


### PR DESCRIPTION
## Summary

Fix the visual shift when the todo list re-renders after deletion.

## Problem

When a todo was deleted, all remaining items would visually shift left then right. This was caused by the `slideIn` animation which used `translateX(-20px)` - every item would animate from the left on each re-render.

## Solution

Changed the `slideIn` keyframe animation to only fade in (opacity 0 → 1) without horizontal movement (removed `translateX`).

## Test plan

- [ ] Delete a todo - list should fade smoothly without horizontal shift
- [ ] Add a todo - appears with fade animation
- [ ] Toggle todo completion - no horizontal shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)