### PR TITLE
fix: Prevent todo content shift on list re-render

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -904,8 +904,7 @@ body.sidebar-resizing * {
     display: flex;
     align-items: center;
     gap: 12px;
-    transition: all 0.3s;
-    animation: slideIn 0.3s ease-out;
+    transition: background 0.3s, transform 0.3s, opacity 0.3s, box-shadow 0.3s;
     border-left: 4px solid transparent;
 }
 


### PR DESCRIPTION
## Summary
- Changed `.todo-item` transition from `all 0.3s` to only specific visual properties (`background, transform, opacity, box-shadow`)
- Removed the `slideIn` animation that ran on every re-render
- This prevents layout properties from animating during list re-renders

## Problem
When switching projects or deleting todos, the content inside todo items would visually shift left then back right. The border stayed still but the lines/content moved.

## Solution
The `transition: all` was transitioning ALL properties including layout ones. Combined with the slideIn animation running on every re-render, this caused the visual jitter. By limiting transitions to only visual properties (not layout), the shift is eliminated.

## Test plan
- [ ] Switch between projects - no content shift
- [ ] Delete a todo - no content shift  
- [ ] Hover effects still work
- [ ] Completed todo opacity transition still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)