### PR TITLE
fix: Eliminate flickering during batch import

### DIFF
--- a/src/ui/modals/ImportModal.js
+++ b/src/ui/modals/ImportModal.js
@@ -1,5 +1,5 @@
 import { store } from '../../core/store.js'
-import { addTodo } from '../../services/todos.js'
+import { batchAddTodos } from '../../services/todos.js'
 
 /**
  * ImportModal controller
@@ -131,19 +131,20 @@ export class ImportModal {
         this.importBtn.textContent = `Importing ${lines.length} todos...`
 
         try {
-            // Import each line as a todo
-            for (const line of lines) {
-                await addTodo({
-                    text: line,
-                    projectId,
-                    categoryId,
-                    contextId,
-                    priorityId,
-                    gtdStatus,
-                    dueDate,
-                    comment: null
-                })
-            }
+            // Prepare all todos for batch import
+            const todosData = lines.map(line => ({
+                text: line,
+                projectId,
+                categoryId,
+                contextId,
+                priorityId,
+                gtdStatus,
+                dueDate,
+                comment: null
+            }))
+
+            // Import all at once - only one store update, no flickering
+            await batchAddTodos(todosData)
 
             this.close()
         } catch (error) {


### PR DESCRIPTION
## Summary
- Added `batchAddTodos()` function that inserts all todos in a single database call
- Store is updated only once after all todos are inserted
- Updated ImportModal to use the new batch function

## Problem
During batch import, each imported todo caused a store update and re-render of the todo list. This created visible flickering under the modal dialog.

## Solution
Instead of calling `addTodo()` in a loop (N database calls + N store updates), we now:
1. Encrypt all todo texts in parallel
2. Insert all todos in a single Supabase call
3. Update the store only once at the end

## Test plan
- [ ] Import multiple todos - no flickering visible
- [ ] All imported todos appear correctly after modal closes
- [ ] Single todo add still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)