### PR TITLE
style: Reduce import textarea height by 30%

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2019,7 +2019,7 @@ body.sidebar-resizing * {
     padding: 12px;
     font-family: inherit;
     resize: vertical;
-    min-height: 200px;
+    min-height: 140px;
     background: #fafafa;
     line-height: 1.6;
 }


### PR DESCRIPTION
## Summary
- Reduced import textarea min-height from 200px to 140px

## Test plan
- [ ] Import modal textarea is shorter but still usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)