### PR TITLE
style: Make import modal more compact to fit on screen

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1904,7 +1904,7 @@ body.sidebar-resizing * {
 .modal-form-split {
     display: flex;
     flex-direction: column;
-    gap: 20px;
+    gap: 12px;
 }
 
 .modal-form-main {
@@ -1912,16 +1912,16 @@ body.sidebar-resizing * {
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 15px;
+    gap: 10px;
 }
 
 .modal-form-sidebar {
     width: 100%;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: 16px 12px;
-    padding: 16px;
-    margin-top: 8px;
+    gap: 10px 12px;
+    padding: 12px;
+    margin-top: 0;
     align-content: start;
     background: linear-gradient(135deg, #f8f9fc 0%, #f0f2f8 100%);
     border-radius: 12px;
@@ -2019,7 +2019,7 @@ body.sidebar-resizing * {
     padding: 12px;
     font-family: inherit;
     resize: vertical;
-    min-height: 140px;
+    min-height: 100px;
     background: #fafafa;
     line-height: 1.6;
 }
@@ -2047,8 +2047,8 @@ body.sidebar-resizing * {
     color: #666;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    margin: 0 0 12px 0;
-    padding-bottom: 8px;
+    margin: 0 0 6px 0;
+    padding-bottom: 6px;
     border-bottom: 1px solid #e0e0e0;
 }
 
@@ -2106,7 +2106,7 @@ body.sidebar-resizing * {
     display: flex;
     gap: 10px;
     margin-top: auto;
-    padding-top: 15px;
+    padding-top: 8px;
 }
 
 .modal-form-split .modal-btn {


### PR DESCRIPTION
## Summary
Multiple spacing reductions to make the import modal fit on smaller screens:
- Textarea height: 140px → 100px
- Section gaps: 20px → 12px, 15px → 10px
- Sidebar padding: 16px → 12px
- Sidebar gaps: 16px → 10px
- Removed extra margin-top from sidebar
- Actions padding: 15px → 8px
- Sidebar title margins reduced

## Test plan
- [ ] Import modal fits entirely on screen at 1080p resolution
- [ ] All elements still readable and clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)