### PR TITLE
fix: Improve unlock modal visibility in dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,7 +510,7 @@
                 </div>
                 <form id="unlockForm" class="modal-form">
                     <div>
-                        <p style="color: #666; margin-bottom: 15px;">
+                        <p class="unlock-description">
                             Enter your password to decrypt your data. Your password is used locally to unlock your encrypted todos and categories.
                         </p>
                         <label for="unlockEmail">Email</label>

--- a/styles.css
+++ b/styles.css
@@ -1709,6 +1709,11 @@ body.sidebar-resizing * {
     gap: 20px;
 }
 
+.unlock-description {
+    color: #666;
+    margin-bottom: 15px;
+}
+
 /* Two-column form layout */
 .form-columns {
     display: flex;
@@ -3526,11 +3531,20 @@ body.sidebar-resizing * {
     background: #1c1c1e;
     backdrop-filter: blur(var(--ios-blur-thick));
     -webkit-backdrop-filter: blur(var(--ios-blur-thick));
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.15);
     box-shadow: 0 25px 80px rgba(0, 0, 0, 0.5);
     border-radius: 20px;
     padding: 24px;
     max-width: 720px;
+    width: 90%;
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+[data-theme="glass"] .unlock-description,
+[data-theme="dark"] .unlock-description,
+[data-theme="clear"] .unlock-description {
+    color: var(--ios-label-secondary);
 }
 
 [data-theme="glass"] .modal-form,


### PR DESCRIPTION
## Summary
- Added explicit `width: 90%`, `max-height: 90vh`, `overflow-y: auto` to dark theme modal
- Replaced hardcoded inline `color: #666` on unlock description with a themed CSS class
- Description text now adapts to theme using `var(--ios-label-secondary)`

## Problem
The unlock modal that appears when loading the app in a new tab was not rendering correctly in dark theme.

## Test plan
- [ ] Open app in new tab while logged in - unlock modal should be visible
- [ ] Modal should have visible background and border in dark theme
- [ ] Description text should be readable in all themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)