### PR TITLE
fix: Restore centered modal alignment for unlock modal

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1594,10 +1594,15 @@ body.sidebar-resizing * {
     bottom: 0;
     background: rgba(0, 0, 0, 0.5);
     z-index: 1000;
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
-    padding-top: 5vh;
     overflow-y: auto;
+}
+
+/* Import modal needs top alignment to prevent jumping during import */
+#importModal.modal-overlay {
+    align-items: flex-start;
+    padding-top: 5vh;
 }
 
 .modal-overlay.active {


### PR DESCRIPTION
## Summary
- Reverted modal-overlay to use `align-items: center` instead of `flex-start`
- Applied top alignment only to `#importModal` specifically

## Problem
The unlock modal was cut/squished to just one row when loading the app in a new tab. Only the password input was visible - header, description, email field, and buttons were all cut off.

## Root Cause
The previous fix for import modal positioning changed ALL modals to use `align-items: flex-start` with `padding-top: 5vh`, which broke the unlock modal.

## Solution
Keep the default centered alignment for all modals, and only apply the top alignment to the import modal using its specific ID selector.

## Test plan
- [ ] Unlock modal displays fully when loading app in new tab
- [ ] Import modal still doesn't jump during batch import

🤖 Generated with [Claude Code](https://claude.com/claude-code)