### PR TITLE
feat: Add recurring todos support

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,6 +314,117 @@
                                 <option value="">No Context</option>
                             </select>
                         </div>
+
+                        <!-- Recurrence Panel -->
+                        <div class="modal-sidebar-divider"></div>
+                        <div class="modal-sidebar-field">
+                            <label for="modalRepeatSelect">
+                                <span class="modal-field-icon">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <polyline points="17 1 21 5 17 9"/>
+                                        <path d="M3 11V9a4 4 0 0 1 4-4h14"/>
+                                        <polyline points="7 23 3 19 7 15"/>
+                                        <path d="M21 13v2a4 4 0 0 1-4 4H3"/>
+                                    </svg>
+                                </span>
+                                <span class="modal-field-label">repeat</span>
+                            </label>
+                            <select id="modalRepeatSelect" class="modal-sidebar-select" aria-label="Repeat">
+                                <option value="none">Does not repeat</option>
+                                <option value="daily">Daily</option>
+                                <option value="weekly">Weekly</option>
+                                <option value="monthly">Monthly</option>
+                                <option value="yearly">Yearly</option>
+                            </select>
+                        </div>
+
+                        <div id="recurrenceOptions" class="recurrence-options" style="display: none;">
+                            <div class="recurrence-interval">
+                                <label>Every</label>
+                                <input type="number" id="recurrenceInterval" class="recurrence-interval-input" value="1" min="1" max="365">
+                                <span id="recurrenceIntervalLabel">day(s)</span>
+                            </div>
+
+                            <div id="weekdayOptions" class="recurrence-weekdays" style="display: none;">
+                                <label>On:</label>
+                                <div class="weekday-checkboxes">
+                                    <label class="weekday-checkbox"><input type="checkbox" name="weekday" value="0"><span>S</span></label>
+                                    <label class="weekday-checkbox"><input type="checkbox" name="weekday" value="1"><span>M</span></label>
+                                    <label class="weekday-checkbox"><input type="checkbox" name="weekday" value="2"><span>T</span></label>
+                                    <label class="weekday-checkbox"><input type="checkbox" name="weekday" value="3"><span>W</span></label>
+                                    <label class="weekday-checkbox"><input type="checkbox" name="weekday" value="4"><span>T</span></label>
+                                    <label class="weekday-checkbox"><input type="checkbox" name="weekday" value="5"><span>F</span></label>
+                                    <label class="weekday-checkbox"><input type="checkbox" name="weekday" value="6"><span>S</span></label>
+                                </div>
+                            </div>
+
+                            <div id="monthlyOptions" class="recurrence-monthly" style="display: none;">
+                                <label>On the:</label>
+                                <div class="monthly-selects">
+                                    <select id="recurrenceOrdinal" class="recurrence-select-small">
+                                        <option value="1">1st</option>
+                                        <option value="2">2nd</option>
+                                        <option value="3">3rd</option>
+                                        <option value="4">4th</option>
+                                        <option value="5">5th</option>
+                                        <option value="-1">Last</option>
+                                    </select>
+                                    <select id="recurrenceDayType" class="recurrence-select-small">
+                                        <option value="day_of_month">day</option>
+                                        <option value="weekday">weekday</option>
+                                        <option value="last_day">last day</option>
+                                    </select>
+                                </div>
+                                <div id="weekdaySelect" class="monthly-weekday" style="display: none;">
+                                    <select id="recurrenceWeekday" class="recurrence-select-small">
+                                        <option value="0">Sunday</option>
+                                        <option value="1">Monday</option>
+                                        <option value="2">Tuesday</option>
+                                        <option value="3">Wednesday</option>
+                                        <option value="4">Thursday</option>
+                                        <option value="5">Friday</option>
+                                        <option value="6">Saturday</option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div id="yearlyOptions" class="recurrence-yearly" style="display: none;">
+                                <label>In:</label>
+                                <select id="recurrenceMonth" class="recurrence-select-small">
+                                    <option value="1">January</option>
+                                    <option value="2">February</option>
+                                    <option value="3">March</option>
+                                    <option value="4">April</option>
+                                    <option value="5">May</option>
+                                    <option value="6">June</option>
+                                    <option value="7">July</option>
+                                    <option value="8">August</option>
+                                    <option value="9">September</option>
+                                    <option value="10">October</option>
+                                    <option value="11">November</option>
+                                    <option value="12">December</option>
+                                </select>
+                            </div>
+
+                            <div class="recurrence-end">
+                                <label>Ends:</label>
+                                <select id="recurrenceEndType" class="recurrence-select-small">
+                                    <option value="never">Never</option>
+                                    <option value="on_date">On date</option>
+                                    <option value="after_count">After</option>
+                                </select>
+                                <input type="date" id="recurrenceEndDate" class="recurrence-end-date" style="display: none;">
+                                <div id="recurrenceEndCountWrapper" class="recurrence-end-count" style="display: none;">
+                                    <input type="number" id="recurrenceEndCount" class="recurrence-count-input" value="10" min="1" max="999">
+                                    <span>occurrences</span>
+                                </div>
+                            </div>
+
+                            <div class="recurrence-preview">
+                                <label>Next occurrences:</label>
+                                <ul id="recurrencePreviewList" class="recurrence-preview-list"></ul>
+                            </div>
+                        </div>
                     </div>
                 </form>
             </div>

--- a/migrations/012_add_recurrence.sql
+++ b/migrations/012_add_recurrence.sql
@@ -1,0 +1,27 @@
+-- Add recurrence columns to todos table for recurring todo support
+-- Template todos (is_template=true) store the recurrence rule but are not shown in the list
+-- Instance todos (template_id set) are linked to a template and shown in the list with recurring icon
+
+-- Add recurrence columns
+-- Note: template_id uses BIGINT to match todos.id column type
+ALTER TABLE todos
+ADD COLUMN IF NOT EXISTS is_template BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS template_id BIGINT REFERENCES todos(id) ON DELETE SET NULL,
+ADD COLUMN IF NOT EXISTS recurrence_rule JSONB DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS recurrence_end_type VARCHAR(20) DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS recurrence_end_date DATE DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS recurrence_end_count INTEGER DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS recurrence_count INTEGER DEFAULT 0;
+
+-- Create indexes for efficient queries
+CREATE INDEX IF NOT EXISTS idx_todos_template_id ON todos(template_id);
+CREATE INDEX IF NOT EXISTS idx_todos_is_template ON todos(is_template) WHERE is_template = TRUE;
+
+-- Add comments for documentation
+COMMENT ON COLUMN todos.is_template IS 'True if this is a recurring template (not shown in list, stores recurrence rule)';
+COMMENT ON COLUMN todos.template_id IS 'Reference to parent template for recurring instances';
+COMMENT ON COLUMN todos.recurrence_rule IS 'JSON object with recurrence configuration (type, interval, weekdays, etc.)';
+COMMENT ON COLUMN todos.recurrence_end_type IS 'End condition: never, on_date, after_count';
+COMMENT ON COLUMN todos.recurrence_end_date IS 'End date for recurrence (when end_type is on_date)';
+COMMENT ON COLUMN todos.recurrence_end_count IS 'Max occurrences (when end_type is after_count)';
+COMMENT ON COLUMN todos.recurrence_count IS 'Number of instances generated so far';

--- a/src/core/store.js
+++ b/src/core/store.js
@@ -12,6 +12,7 @@ class Store {
 
             // Data collections
             todos: [],
+            templates: [], // Recurring todo templates
             categories: [],
             priorities: [],
             contexts: [],
@@ -121,6 +122,7 @@ class Store {
             encryptionKey: null,
             pendingUser: null,
             todos: [],
+            templates: [],
             categories: [],
             priorities: [],
             contexts: [],

--- a/src/services/todos.js
+++ b/src/services/todos.js
@@ -2,6 +2,7 @@ import { supabase } from '../core/supabase.js'
 import { store } from '../core/store.js'
 import { events, Events } from '../core/events.js'
 import { encrypt, decrypt } from './auth.js'
+import { calculateNextOccurrence, isRecurrenceEnded } from '../utils/recurrence.js'
 
 /**
  * Load all todos for the current user
@@ -18,8 +19,15 @@ export async function loadTodos() {
         throw error
     }
 
+    // Filter out template todos (they're not shown in the list)
+    const visibleTodos = data.filter(todo => !todo.is_template)
+
+    // Store templates separately for recurrence generation
+    const templates = data.filter(todo => todo.is_template)
+    store.set('templates', templates)
+
     // Decrypt todo texts and comments
-    const todos = await Promise.all(data.map(async (todo) => ({
+    const todos = await Promise.all(visibleTodos.map(async (todo) => ({
         ...todo,
         text: await decrypt(todo.text),
         comment: todo.comment ? await decrypt(todo.comment) : null
@@ -27,6 +35,10 @@ export async function loadTodos() {
 
     store.set('todos', todos)
     events.emit(Events.TODOS_LOADED, todos)
+
+    // Check for any pending recurrences that need catch-up
+    await checkPendingRecurrences()
+
     return todos
 }
 
@@ -222,6 +234,12 @@ export async function toggleTodo(todoId) {
     todo.gtd_status = newGtdStatus
     store.set('todos', [...todos])
     events.emit(Events.TODOS_UPDATED)
+
+    // If completing a recurring instance, generate the next occurrence
+    if (newCompleted && todo.template_id) {
+        await generateNextRecurrence(todo.template_id, todo.due_date)
+    }
+
     return todo
 }
 
@@ -448,4 +466,329 @@ export function getGtdCount(status) {
         return todos.filter(t => t.due_date && t.gtd_status !== 'done').length
     }
     return todos.filter(t => t.gtd_status === status).length
+}
+
+// ============================================
+// Recurring Todos Functions
+// ============================================
+
+/**
+ * Create a recurring todo with a template and first instance
+ * @param {Object} todoData - Todo data (text, categoryId, etc.)
+ * @param {Object} recurrenceRule - Recurrence rule object
+ * @param {Object} endCondition - End condition { type, date?, count? }
+ * @returns {Promise<Object>} The created instance todo
+ */
+export async function createRecurringTodo(todoData, recurrenceRule, endCondition) {
+    const currentUser = store.get('currentUser')
+    const { text, categoryId, projectId, priorityId, gtdStatus, contextId, dueDate, comment } = todoData
+
+    // Encrypt text and comment
+    const encryptedText = await encrypt(text)
+    const encryptedComment = comment ? await encrypt(comment) : null
+
+    // Create the template first
+    const { data: templateData, error: templateError } = await supabase
+        .from('todos')
+        .insert({
+            user_id: currentUser.id,
+            text: encryptedText,
+            completed: false,
+            category_id: categoryId || null,
+            project_id: projectId || null,
+            priority_id: priorityId || null,
+            gtd_status: 'scheduled', // Templates are always scheduled
+            context_id: contextId || null,
+            due_date: dueDate || null,
+            comment: encryptedComment,
+            is_template: true,
+            recurrence_rule: recurrenceRule,
+            recurrence_end_type: endCondition.type || 'never',
+            recurrence_end_date: endCondition.date || null,
+            recurrence_end_count: endCondition.count || null,
+            recurrence_count: 0
+        })
+        .select()
+
+    if (templateError) {
+        console.error('Error creating recurring template:', templateError)
+        throw templateError
+    }
+
+    const template = templateData[0]
+
+    // Create the first instance
+    const { data: instanceData, error: instanceError } = await supabase
+        .from('todos')
+        .insert({
+            user_id: currentUser.id,
+            text: encryptedText,
+            completed: false,
+            category_id: categoryId || null,
+            project_id: projectId || null,
+            priority_id: priorityId || null,
+            gtd_status: gtdStatus || 'scheduled',
+            context_id: contextId || null,
+            due_date: dueDate || null,
+            comment: encryptedComment,
+            is_template: false,
+            template_id: template.id
+        })
+        .select()
+
+    if (instanceError) {
+        console.error('Error creating recurring instance:', instanceError)
+        throw instanceError
+    }
+
+    // Update template recurrence count
+    await supabase
+        .from('todos')
+        .update({ recurrence_count: 1 })
+        .eq('id', template.id)
+
+    // Add instance to local state
+    const instance = { ...instanceData[0], text, comment }
+    const todos = [...store.get('todos'), instance]
+    store.set('todos', todos)
+
+    // Update templates in store
+    const templates = store.get('templates') || []
+    templates.push({ ...template, recurrence_count: 1 })
+    store.set('templates', templates)
+
+    events.emit(Events.TODO_ADDED, instance)
+    return instance
+}
+
+/**
+ * Generate the next recurrence instance for a template
+ * @param {string} templateId - Template todo ID
+ * @param {string} fromDate - Date to calculate from (YYYY-MM-DD)
+ * @returns {Promise<Object|null>} The created instance or null if ended
+ */
+export async function generateNextRecurrence(templateId, fromDate) {
+    // Get template from store or fetch from DB
+    let templates = store.get('templates') || []
+    let template = templates.find(t => t.id === templateId)
+
+    if (!template) {
+        // Fetch from DB if not in store
+        const { data, error } = await supabase
+            .from('todos')
+            .select('*')
+            .eq('id', templateId)
+            .single()
+
+        if (error || !data) {
+            console.error('Template not found:', templateId)
+            return null
+        }
+        template = data
+    }
+
+    // Check if recurrence has ended
+    if (isRecurrenceEnded(template)) {
+        console.log('Recurrence ended for template:', templateId)
+        return null
+    }
+
+    // Calculate next due date
+    const rule = template.recurrence_rule
+    if (!rule) {
+        console.error('No recurrence rule on template:', templateId)
+        return null
+    }
+
+    const nextDueDate = calculateNextOccurrence(rule, fromDate)
+    if (!nextDueDate) {
+        console.error('Could not calculate next occurrence:', rule, fromDate)
+        return null
+    }
+
+    // Check if next date exceeds end date
+    if (template.recurrence_end_type === 'on_date' && template.recurrence_end_date) {
+        if (nextDueDate > template.recurrence_end_date) {
+            console.log('Next occurrence exceeds end date')
+            return null
+        }
+    }
+
+    // Check if count limit reached
+    const newCount = (template.recurrence_count || 0) + 1
+    if (template.recurrence_end_type === 'after_count' && template.recurrence_end_count) {
+        if (newCount > template.recurrence_end_count) {
+            console.log('Recurrence count limit reached')
+            return null
+        }
+    }
+
+    const currentUser = store.get('currentUser')
+
+    // Create new instance
+    const { data: instanceData, error: instanceError } = await supabase
+        .from('todos')
+        .insert({
+            user_id: currentUser.id,
+            text: template.text, // Already encrypted
+            completed: false,
+            category_id: template.category_id,
+            project_id: template.project_id,
+            priority_id: template.priority_id,
+            gtd_status: 'scheduled',
+            context_id: template.context_id,
+            due_date: nextDueDate,
+            comment: template.comment,
+            is_template: false,
+            template_id: template.id
+        })
+        .select()
+
+    if (instanceError) {
+        console.error('Error creating next recurrence:', instanceError)
+        throw instanceError
+    }
+
+    // Update template recurrence count
+    await supabase
+        .from('todos')
+        .update({ recurrence_count: newCount })
+        .eq('id', template.id)
+
+    // Update template in store
+    template.recurrence_count = newCount
+    templates = templates.map(t => t.id === templateId ? template : t)
+    store.set('templates', templates)
+
+    // Decrypt and add instance to local state
+    const instance = {
+        ...instanceData[0],
+        text: await decrypt(instanceData[0].text),
+        comment: instanceData[0].comment ? await decrypt(instanceData[0].comment) : null
+    }
+    const todos = [...store.get('todos'), instance]
+    store.set('todos', todos)
+
+    events.emit(Events.TODO_ADDED, instance)
+    return instance
+}
+
+/**
+ * Check for pending recurrences that need catch-up generation
+ * Called on app load to handle cases where user was offline
+ */
+export async function checkPendingRecurrences() {
+    const templates = store.get('templates') || []
+    const todos = store.get('todos') || []
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    for (const template of templates) {
+        if (!template.recurrence_rule) continue
+        if (isRecurrenceEnded(template)) continue
+
+        // Find the latest instance for this template
+        const instances = todos.filter(t => t.template_id === template.id)
+        if (instances.length === 0) continue
+
+        // Get the most recent instance's due date
+        const latestInstance = instances.reduce((latest, instance) => {
+            if (!latest) return instance
+            if (!instance.due_date) return latest
+            if (!latest.due_date) return instance
+            return instance.due_date > latest.due_date ? instance : latest
+        }, null)
+
+        if (!latestInstance || !latestInstance.due_date) continue
+
+        // Check if latest instance is past due and completed
+        const latestDate = new Date(latestInstance.due_date)
+        latestDate.setHours(0, 0, 0, 0)
+
+        // Only generate catch-up if the latest instance is completed and past due
+        if (latestInstance.completed && latestDate < today) {
+            console.log('Generating catch-up recurrence for:', template.id)
+            await generateNextRecurrence(template.id, latestInstance.due_date)
+        }
+    }
+}
+
+/**
+ * Stop a recurring series (no more instances will be generated)
+ * @param {string} templateId - Template todo ID
+ */
+export async function stopRecurrence(templateId) {
+    // Set end condition to "after_count" with current count
+    const templates = store.get('templates') || []
+    const template = templates.find(t => t.id === templateId)
+
+    if (!template) {
+        console.error('Template not found:', templateId)
+        return
+    }
+
+    const { error } = await supabase
+        .from('todos')
+        .update({
+            recurrence_end_type: 'after_count',
+            recurrence_end_count: template.recurrence_count || 0
+        })
+        .eq('id', templateId)
+
+    if (error) {
+        console.error('Error stopping recurrence:', error)
+        throw error
+    }
+
+    // Update local state
+    template.recurrence_end_type = 'after_count'
+    template.recurrence_end_count = template.recurrence_count || 0
+    store.set('templates', [...templates])
+}
+
+/**
+ * Delete an entire recurring series (template + all instances)
+ * @param {string} templateId - Template todo ID
+ */
+export async function deleteRecurringSeries(templateId) {
+    // Delete all instances first
+    const { error: instancesError } = await supabase
+        .from('todos')
+        .delete()
+        .eq('template_id', templateId)
+
+    if (instancesError) {
+        console.error('Error deleting recurring instances:', instancesError)
+        throw instancesError
+    }
+
+    // Delete the template
+    const { error: templateError } = await supabase
+        .from('todos')
+        .delete()
+        .eq('id', templateId)
+
+    if (templateError) {
+        console.error('Error deleting recurring template:', templateError)
+        throw templateError
+    }
+
+    // Update local state
+    const todos = store.get('todos').filter(t => t.template_id !== templateId)
+    store.set('todos', todos)
+
+    const templates = (store.get('templates') || []).filter(t => t.id !== templateId)
+    store.set('templates', templates)
+
+    events.emit(Events.TODOS_LOADED, todos)
+}
+
+/**
+ * Get template for a recurring todo instance
+ * @param {string} templateId - Template todo ID
+ * @returns {Object|null} Template todo or null
+ */
+export function getTemplateById(templateId) {
+    const templates = store.get('templates') || []
+    return templates.find(t => t.id === templateId) || null
 }

--- a/src/ui/TodoList.js
+++ b/src/ui/TodoList.js
@@ -187,6 +187,18 @@ export function renderTodos(container, options = {}) {
             ? `<div class="todo-comment">${escapeHtml(todo.comment)}</div>`
             : ''
 
+        // Recurring icon for todos linked to a template
+        const recurringIcon = todo.template_id
+            ? `<span class="recurring-icon" title="Recurring">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <polyline points="17 1 21 5 17 9"/>
+                    <path d="M3 11V9a4 4 0 0 1 4-4h14"/>
+                    <polyline points="7 23 3 19 7 15"/>
+                    <path d="M21 13v2a4 4 0 0 1-4 4H3"/>
+                </svg>
+               </span>`
+            : ''
+
         if (category) {
             li.style.borderLeftColor = validateColor(category.color)
         }
@@ -199,6 +211,7 @@ export function renderTodos(container, options = {}) {
                 ${isCompleted ? 'checked' : ''}
                 data-id="${todo.id}"
             >
+            ${recurringIcon}
             <div class="todo-content">
                 <span class="todo-text">${escapeHtml(todo.text)}</span>
                 ${commentHtml}

--- a/src/utils/recurrence.js
+++ b/src/utils/recurrence.js
@@ -1,0 +1,404 @@
+/**
+ * Recurrence calculation utilities for recurring todos
+ *
+ * Recurrence Rule Schema:
+ * {
+ *   type: 'daily' | 'weekly' | 'monthly' | 'yearly',
+ *   interval: number,           // Every X days/weeks/months/years
+ *   weekdays?: number[],        // For weekly: [0-6] (Sun-Sat)
+ *   dayType?: 'day_of_month' | 'weekday' | 'last_day',  // For monthly/yearly
+ *   dayOfMonth?: number,        // 1-31
+ *   weekdayOrdinal?: number,    // 1=first, 2=second, -1=last
+ *   weekday?: number,           // 0-6 for specific weekday
+ *   month?: number,             // 1-12 for yearly
+ *   startDate: string           // ISO date YYYY-MM-DD
+ * }
+ */
+
+/**
+ * Parse a date string (YYYY-MM-DD) into a Date object at midnight local time
+ * @param {string} dateString - Date in YYYY-MM-DD format
+ * @returns {Date}
+ */
+function parseDate(dateString) {
+    const [year, month, day] = dateString.split('-').map(Number)
+    return new Date(year, month - 1, day)
+}
+
+/**
+ * Format a Date object as YYYY-MM-DD
+ * @param {Date} date - Date to format
+ * @returns {string}
+ */
+function formatDate(date) {
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
+}
+
+/**
+ * Get the last day of a month
+ * @param {number} year
+ * @param {number} month - 0-indexed (0 = January)
+ * @returns {number}
+ */
+function getLastDayOfMonth(year, month) {
+    return new Date(year, month + 1, 0).getDate()
+}
+
+/**
+ * Find the nth weekday of a month (e.g., 2nd Tuesday)
+ * @param {number} year
+ * @param {number} month - 0-indexed
+ * @param {number} weekday - 0-6 (Sun-Sat)
+ * @param {number} ordinal - 1-5 for first through fifth, -1 for last
+ * @returns {Date|null}
+ */
+function getNthWeekdayOfMonth(year, month, weekday, ordinal) {
+    if (ordinal === -1) {
+        // Find last occurrence
+        const lastDay = getLastDayOfMonth(year, month)
+        for (let day = lastDay; day >= 1; day--) {
+            const date = new Date(year, month, day)
+            if (date.getDay() === weekday) {
+                return date
+            }
+        }
+        return null
+    }
+
+    // Find nth occurrence
+    let count = 0
+    for (let day = 1; day <= 31; day++) {
+        const date = new Date(year, month, day)
+        // Stop if we've gone past this month
+        if (date.getMonth() !== month) break
+
+        if (date.getDay() === weekday) {
+            count++
+            if (count === ordinal) {
+                return date
+            }
+        }
+    }
+    return null
+}
+
+/**
+ * Calculate the next occurrence date from a given date based on recurrence rule
+ * @param {Object} rule - Recurrence rule object
+ * @param {string} fromDate - Start date in YYYY-MM-DD format
+ * @returns {string|null} Next occurrence date in YYYY-MM-DD format, or null if invalid
+ */
+export function calculateNextOccurrence(rule, fromDate) {
+    if (!rule || !rule.type || !fromDate) return null
+
+    const current = parseDate(fromDate)
+    const interval = rule.interval || 1
+
+    switch (rule.type) {
+        case 'daily': {
+            const next = new Date(current)
+            next.setDate(next.getDate() + interval)
+            return formatDate(next)
+        }
+
+        case 'weekly': {
+            const weekdays = rule.weekdays || [current.getDay()]
+            if (weekdays.length === 0) return null
+
+            // Sort weekdays for easier calculation
+            const sortedWeekdays = [...weekdays].sort((a, b) => a - b)
+            const currentDay = current.getDay()
+
+            // Find next weekday in the current week
+            let next = new Date(current)
+            for (const wd of sortedWeekdays) {
+                if (wd > currentDay) {
+                    next.setDate(current.getDate() + (wd - currentDay))
+                    return formatDate(next)
+                }
+            }
+
+            // Move to first weekday of next interval week
+            const daysUntilNextWeek = 7 - currentDay + sortedWeekdays[0]
+            next.setDate(current.getDate() + daysUntilNextWeek + (interval - 1) * 7)
+            return formatDate(next)
+        }
+
+        case 'monthly': {
+            const dayType = rule.dayType || 'day_of_month'
+            let next = new Date(current)
+
+            // Move to next interval month
+            next.setMonth(next.getMonth() + interval)
+
+            if (dayType === 'day_of_month') {
+                const targetDay = rule.dayOfMonth || current.getDate()
+                const lastDay = getLastDayOfMonth(next.getFullYear(), next.getMonth())
+                next.setDate(Math.min(targetDay, lastDay))
+            } else if (dayType === 'weekday') {
+                const targetWeekday = rule.weekday ?? current.getDay()
+                const ordinal = rule.weekdayOrdinal || 1
+                const result = getNthWeekdayOfMonth(next.getFullYear(), next.getMonth(), targetWeekday, ordinal)
+                if (result) next = result
+            } else if (dayType === 'last_day') {
+                next.setDate(getLastDayOfMonth(next.getFullYear(), next.getMonth()))
+            }
+
+            return formatDate(next)
+        }
+
+        case 'yearly': {
+            const dayType = rule.dayType || 'day_of_month'
+            let next = new Date(current)
+
+            // Move to next interval year
+            next.setFullYear(next.getFullYear() + interval)
+
+            // Set month if specified
+            if (rule.month !== undefined) {
+                next.setMonth(rule.month - 1) // month is 1-indexed in rule
+            }
+
+            if (dayType === 'day_of_month') {
+                const targetDay = rule.dayOfMonth || current.getDate()
+                const lastDay = getLastDayOfMonth(next.getFullYear(), next.getMonth())
+                next.setDate(Math.min(targetDay, lastDay))
+            } else if (dayType === 'weekday') {
+                const targetWeekday = rule.weekday ?? current.getDay()
+                const ordinal = rule.weekdayOrdinal || 1
+                const result = getNthWeekdayOfMonth(next.getFullYear(), next.getMonth(), targetWeekday, ordinal)
+                if (result) next = result
+            } else if (dayType === 'last_day') {
+                next.setDate(getLastDayOfMonth(next.getFullYear(), next.getMonth()))
+            }
+
+            return formatDate(next)
+        }
+
+        default:
+            return null
+    }
+}
+
+/**
+ * Get the next N occurrences for preview display
+ * @param {Object} rule - Recurrence rule object
+ * @param {number} n - Number of occurrences to generate
+ * @param {string} startDate - Start date in YYYY-MM-DD format (optional, defaults to today)
+ * @returns {string[]} Array of dates in YYYY-MM-DD format
+ */
+export function getNextNOccurrences(rule, n, startDate) {
+    if (!rule || !rule.type || n <= 0) return []
+
+    const start = startDate || formatDate(new Date())
+    const occurrences = []
+    let current = start
+
+    for (let i = 0; i < n && i < 10; i++) { // Cap at 10 for safety
+        const next = calculateNextOccurrence(rule, current)
+        if (!next) break
+        occurrences.push(next)
+        current = next
+    }
+
+    return occurrences
+}
+
+/**
+ * Format a recurrence rule as human-readable text
+ * @param {Object} rule - Recurrence rule object
+ * @returns {string} Human-readable description
+ */
+export function formatRecurrenceSummary(rule) {
+    if (!rule || !rule.type) return 'No recurrence'
+
+    const interval = rule.interval || 1
+    const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+    const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
+                        'July', 'August', 'September', 'October', 'November', 'December']
+    const ordinalNames = ['first', 'second', 'third', 'fourth', 'fifth', 'last']
+
+    switch (rule.type) {
+        case 'daily': {
+            if (interval === 1) return 'Every day'
+            return `Every ${interval} days`
+        }
+
+        case 'weekly': {
+            const weekdays = rule.weekdays || []
+            const dayList = weekdays.map(d => dayNames[d]).join(', ')
+            if (interval === 1) {
+                return weekdays.length > 0 ? `Every week on ${dayList}` : 'Every week'
+            }
+            return weekdays.length > 0
+                ? `Every ${interval} weeks on ${dayList}`
+                : `Every ${interval} weeks`
+        }
+
+        case 'monthly': {
+            const dayType = rule.dayType || 'day_of_month'
+            let dayDesc = ''
+
+            if (dayType === 'day_of_month') {
+                dayDesc = `day ${rule.dayOfMonth || 1}`
+            } else if (dayType === 'weekday') {
+                const ordinal = rule.weekdayOrdinal === -1 ? 'last' : ordinalNames[(rule.weekdayOrdinal || 1) - 1]
+                dayDesc = `${ordinal} ${dayNames[rule.weekday ?? 0]}`
+            } else if (dayType === 'last_day') {
+                dayDesc = 'last day'
+            }
+
+            if (interval === 1) return `Every month on the ${dayDesc}`
+            return `Every ${interval} months on the ${dayDesc}`
+        }
+
+        case 'yearly': {
+            const dayType = rule.dayType || 'day_of_month'
+            const month = monthNames[(rule.month || 1) - 1]
+            let dayDesc = ''
+
+            if (dayType === 'day_of_month') {
+                dayDesc = `${rule.dayOfMonth || 1}`
+            } else if (dayType === 'weekday') {
+                const ordinal = rule.weekdayOrdinal === -1 ? 'last' : ordinalNames[(rule.weekdayOrdinal || 1) - 1]
+                dayDesc = `${ordinal} ${dayNames[rule.weekday ?? 0]}`
+            } else if (dayType === 'last_day') {
+                dayDesc = 'last day'
+            }
+
+            if (interval === 1) return `Every year on ${month} ${dayDesc}`
+            return `Every ${interval} years on ${month} ${dayDesc}`
+        }
+
+        default:
+            return 'Custom recurrence'
+    }
+}
+
+/**
+ * Check if a recurrence has reached its end condition
+ * @param {Object} template - Template todo object with recurrence settings
+ * @returns {boolean} True if recurrence has ended
+ */
+export function isRecurrenceEnded(template) {
+    if (!template) return true
+
+    const endType = template.recurrence_end_type
+
+    if (!endType || endType === 'never') return false
+
+    if (endType === 'on_date' && template.recurrence_end_date) {
+        const today = new Date()
+        today.setHours(0, 0, 0, 0)
+        const endDate = parseDate(template.recurrence_end_date)
+        return today > endDate
+    }
+
+    if (endType === 'after_count' && template.recurrence_end_count) {
+        return (template.recurrence_count || 0) >= template.recurrence_end_count
+    }
+
+    return false
+}
+
+/**
+ * Validate a recurrence rule object
+ * @param {Object} rule - Recurrence rule to validate
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateRecurrenceRule(rule) {
+    if (!rule) return { valid: false, error: 'Rule is required' }
+
+    if (!['daily', 'weekly', 'monthly', 'yearly'].includes(rule.type)) {
+        return { valid: false, error: 'Invalid recurrence type' }
+    }
+
+    if (!rule.interval || rule.interval < 1 || rule.interval > 365) {
+        return { valid: false, error: 'Interval must be between 1 and 365' }
+    }
+
+    if (rule.type === 'weekly') {
+        if (rule.weekdays && (!Array.isArray(rule.weekdays) || rule.weekdays.length === 0)) {
+            return { valid: false, error: 'At least one weekday must be selected for weekly recurrence' }
+        }
+        if (rule.weekdays && rule.weekdays.some(d => d < 0 || d > 6)) {
+            return { valid: false, error: 'Weekdays must be between 0 (Sun) and 6 (Sat)' }
+        }
+    }
+
+    if (rule.type === 'monthly' || rule.type === 'yearly') {
+        if (rule.dayType && !['day_of_month', 'weekday', 'last_day'].includes(rule.dayType)) {
+            return { valid: false, error: 'Invalid day type' }
+        }
+        if (rule.dayOfMonth && (rule.dayOfMonth < 1 || rule.dayOfMonth > 31)) {
+            return { valid: false, error: 'Day of month must be between 1 and 31' }
+        }
+        if (rule.weekday !== undefined && (rule.weekday < 0 || rule.weekday > 6)) {
+            return { valid: false, error: 'Weekday must be between 0 (Sun) and 6 (Sat)' }
+        }
+        if (rule.weekdayOrdinal && ![1, 2, 3, 4, 5, -1].includes(rule.weekdayOrdinal)) {
+            return { valid: false, error: 'Ordinal must be 1-5 or -1 (last)' }
+        }
+    }
+
+    if (rule.type === 'yearly') {
+        if (rule.month && (rule.month < 1 || rule.month > 12)) {
+            return { valid: false, error: 'Month must be between 1 and 12' }
+        }
+    }
+
+    return { valid: true }
+}
+
+/**
+ * Build a recurrence rule from form values
+ * @param {Object} formValues - Form values
+ * @returns {Object|null} Recurrence rule or null if no recurrence
+ */
+export function buildRecurrenceRule(formValues) {
+    if (!formValues.type || formValues.type === 'none') return null
+
+    const rule = {
+        type: formValues.type,
+        interval: parseInt(formValues.interval, 10) || 1,
+        startDate: formValues.startDate || formatDate(new Date())
+    }
+
+    if (formValues.type === 'weekly' && formValues.weekdays) {
+        rule.weekdays = formValues.weekdays
+    }
+
+    if (formValues.type === 'monthly' || formValues.type === 'yearly') {
+        rule.dayType = formValues.dayType || 'day_of_month'
+
+        if (rule.dayType === 'day_of_month') {
+            rule.dayOfMonth = parseInt(formValues.dayOfMonth, 10) || 1
+        } else if (rule.dayType === 'weekday') {
+            rule.weekdayOrdinal = parseInt(formValues.weekdayOrdinal, 10) || 1
+            rule.weekday = parseInt(formValues.weekday, 10) || 0
+        }
+    }
+
+    if (formValues.type === 'yearly' && formValues.month) {
+        rule.month = parseInt(formValues.month, 10)
+    }
+
+    return rule
+}
+
+/**
+ * Format a date for preview display
+ * @param {string} dateString - Date in YYYY-MM-DD format
+ * @returns {string} Formatted date string
+ */
+export function formatPreviewDate(dateString) {
+    const date = parseDate(dateString)
+    return date.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+    })
+}

--- a/styles.css
+++ b/styles.css
@@ -2111,6 +2111,244 @@ body.sidebar-resizing * {
     border-color: #ccc;
 }
 
+.modal-sidebar-divider {
+    grid-column: 1 / -1;
+    height: 1px;
+    background: rgba(0, 0, 0, 0.1);
+    margin: 8px 0;
+}
+
+/* Recurrence Panel Styles */
+.recurrence-options {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 8px 0;
+}
+
+.recurrence-interval {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+}
+
+.recurrence-interval label {
+    color: #666;
+    font-weight: 500;
+}
+
+.recurrence-interval-input {
+    width: 60px;
+    padding: 6px 8px;
+    font-size: 13px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    text-align: center;
+}
+
+.recurrence-interval-input:focus {
+    outline: none;
+    border-color: var(--accent-color);
+}
+
+#recurrenceIntervalLabel {
+    color: #666;
+}
+
+.recurrence-weekdays {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.recurrence-weekdays > label {
+    font-size: 12px;
+    color: #666;
+    font-weight: 500;
+}
+
+.weekday-checkboxes {
+    display: flex;
+    gap: 4px;
+}
+
+.weekday-checkbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.weekday-checkbox input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.weekday-checkbox span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: #f0f0f0;
+    color: #666;
+    font-size: 11px;
+    font-weight: 600;
+    transition: all 0.15s ease;
+}
+
+.weekday-checkbox input:checked + span {
+    background: var(--accent-color);
+    color: white;
+}
+
+.weekday-checkbox:hover span {
+    background: #e0e0e0;
+}
+
+.weekday-checkbox input:checked:hover + span {
+    background: var(--accent-color-hover, #0056b3);
+}
+
+.recurrence-monthly,
+.recurrence-yearly {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.recurrence-monthly > label,
+.recurrence-yearly > label {
+    font-size: 12px;
+    color: #666;
+    font-weight: 500;
+}
+
+.monthly-selects {
+    display: flex;
+    gap: 6px;
+}
+
+.monthly-weekday {
+    margin-top: 6px;
+}
+
+.recurrence-select-small {
+    padding: 6px 8px;
+    font-size: 12px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background: white;
+    cursor: pointer;
+}
+
+.recurrence-select-small:focus {
+    outline: none;
+    border-color: var(--accent-color);
+}
+
+.recurrence-end {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+}
+
+.recurrence-end > label {
+    font-size: 12px;
+    color: #666;
+    font-weight: 500;
+}
+
+.recurrence-end-date {
+    padding: 6px 8px;
+    font-size: 12px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+}
+
+.recurrence-end-date:focus {
+    outline: none;
+    border-color: var(--accent-color);
+}
+
+.recurrence-end-count {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: #666;
+}
+
+.recurrence-count-input {
+    width: 50px;
+    padding: 6px 8px;
+    font-size: 12px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    text-align: center;
+}
+
+.recurrence-count-input:focus {
+    outline: none;
+    border-color: var(--accent-color);
+}
+
+.recurrence-preview {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 4px;
+}
+
+.recurrence-preview > label {
+    font-size: 11px;
+    color: #888;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.recurrence-preview-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.recurrence-preview-list li {
+    font-size: 11px;
+    padding: 3px 8px;
+    background: rgba(0, 122, 255, 0.1);
+    color: var(--accent-color);
+    border-radius: 10px;
+}
+
+/* Recurring Todo Icon */
+.recurring-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    margin-right: 6px;
+    color: var(--accent-color);
+    opacity: 0.7;
+    flex-shrink: 0;
+}
+
+.recurring-icon svg {
+    width: 14px;
+    height: 14px;
+}
+
 /* Updated modal actions for split layout */
 .modal-form-split .modal-actions {
     display: flex;
@@ -3067,6 +3305,99 @@ body.sidebar-resizing * {
 [data-theme="clear"] .modal-sidebar-select:hover,
 [data-theme="clear"] .modal-sidebar-input:hover {
     border-color: var(--ios-gray3);
+}
+
+/* Dark theme recurrence panel */
+[data-theme="glass"] .modal-sidebar-divider,
+[data-theme="dark"] .modal-sidebar-divider,
+[data-theme="clear"] .modal-sidebar-divider {
+    background: var(--ios-separator);
+}
+
+[data-theme="glass"] .recurrence-interval label,
+[data-theme="dark"] .recurrence-interval label,
+[data-theme="clear"] .recurrence-interval label,
+[data-theme="glass"] #recurrenceIntervalLabel,
+[data-theme="dark"] #recurrenceIntervalLabel,
+[data-theme="clear"] #recurrenceIntervalLabel {
+    color: var(--ios-label-secondary);
+}
+
+[data-theme="glass"] .recurrence-interval-input,
+[data-theme="dark"] .recurrence-interval-input,
+[data-theme="clear"] .recurrence-interval-input,
+[data-theme="glass"] .recurrence-select-small,
+[data-theme="dark"] .recurrence-select-small,
+[data-theme="clear"] .recurrence-select-small,
+[data-theme="glass"] .recurrence-end-date,
+[data-theme="dark"] .recurrence-end-date,
+[data-theme="clear"] .recurrence-end-date,
+[data-theme="glass"] .recurrence-count-input,
+[data-theme="dark"] .recurrence-count-input,
+[data-theme="clear"] .recurrence-count-input {
+    background: var(--ios-bg-secondary);
+    border-color: var(--ios-separator);
+    color: var(--ios-label);
+}
+
+[data-theme="glass"] .recurrence-weekdays > label,
+[data-theme="dark"] .recurrence-weekdays > label,
+[data-theme="clear"] .recurrence-weekdays > label,
+[data-theme="glass"] .recurrence-monthly > label,
+[data-theme="dark"] .recurrence-monthly > label,
+[data-theme="clear"] .recurrence-monthly > label,
+[data-theme="glass"] .recurrence-yearly > label,
+[data-theme="dark"] .recurrence-yearly > label,
+[data-theme="clear"] .recurrence-yearly > label,
+[data-theme="glass"] .recurrence-end > label,
+[data-theme="dark"] .recurrence-end > label,
+[data-theme="clear"] .recurrence-end > label {
+    color: var(--ios-label-secondary);
+}
+
+[data-theme="glass"] .weekday-checkbox span,
+[data-theme="dark"] .weekday-checkbox span,
+[data-theme="clear"] .weekday-checkbox span {
+    background: var(--ios-bg-secondary);
+    color: var(--ios-label-secondary);
+}
+
+[data-theme="glass"] .weekday-checkbox:hover span,
+[data-theme="dark"] .weekday-checkbox:hover span,
+[data-theme="clear"] .weekday-checkbox:hover span {
+    background: var(--ios-bg-tertiary);
+}
+
+[data-theme="glass"] .weekday-checkbox input:checked + span,
+[data-theme="dark"] .weekday-checkbox input:checked + span,
+[data-theme="clear"] .weekday-checkbox input:checked + span {
+    background: var(--ios-blue);
+    color: white;
+}
+
+[data-theme="glass"] .recurrence-end-count,
+[data-theme="dark"] .recurrence-end-count,
+[data-theme="clear"] .recurrence-end-count {
+    color: var(--ios-label-secondary);
+}
+
+[data-theme="glass"] .recurrence-preview > label,
+[data-theme="dark"] .recurrence-preview > label,
+[data-theme="clear"] .recurrence-preview > label {
+    color: var(--ios-label-tertiary);
+}
+
+[data-theme="glass"] .recurrence-preview-list li,
+[data-theme="dark"] .recurrence-preview-list li,
+[data-theme="clear"] .recurrence-preview-list li {
+    background: rgba(0, 122, 255, 0.15);
+    color: var(--ios-blue);
+}
+
+[data-theme="glass"] .recurring-icon,
+[data-theme="dark"] .recurring-icon,
+[data-theme="clear"] .recurring-icon {
+    color: var(--ios-blue);
 }
 
 /* iOS Checkbox Label */


### PR DESCRIPTION
## Summary

- Add ability to create recurring todos with daily, weekly, monthly, and yearly patterns
- Template/instance model: templates store recurrence rules, instances are shown in the list
- Recurrence panel in todo modal with interval, weekday selection, and end condition options
- Auto-generation of next instance when completing a recurring todo
- Catch-up generation on app load for missed recurrences

## Changes

### New Files
- `migrations/012_add_recurrence.sql` - Database migration for recurrence columns
- `src/utils/recurrence.js` - Utility functions for date calculations

### Modified Files
- `src/services/todos.js` - Added recurrence functions (createRecurringTodo, generateNextRecurrence, etc.)
- `src/ui/modals/TodoModal.js` - Added recurrence panel handling
- `src/ui/TodoList.js` - Added recurring icon to todo items
- `src/core/store.js` - Added templates state
- `index.html` - Added recurrence panel HTML
- `styles.css` - Added recurrence panel and icon styles

## Test plan

- [ ] Run migration on Supabase
- [ ] Create daily recurring todo, complete it, verify next instance appears
- [ ] Create weekly todo on specific days, verify correct dates
- [ ] Create monthly todo (e.g., 2nd Tuesday), verify calculation
- [ ] Create yearly todo, verify year increments
- [ ] Test "ends after X occurrences" - verify stops at limit
- [ ] Test "ends on date" - verify no instance after end date
- [ ] Verify recurring icon appears on recurring instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)