### PR TITLE
chore: Add pre-commit hook for CSS selector validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Dependencies
+node_modules/
+
+# Lock files (optional - can include if you want reproducible builds)
+package-lock.json
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Debug
+npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "todolist",
+  "version": "2.0.0",
+  "private": true,
+  "description": "A single-page todo list application with user authentication and cloud sync",
+  "scripts": {
+    "check:css": "node scripts/check-css-selectors.js",
+    "prepare": "node scripts/setup-hooks.js"
+  },
+  "devDependencies": {
+    "css-tree": "^2.3.1",
+    "jsdom": "^24.0.0"
+  }
+}

--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -126,6 +126,7 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.todo-context-badge/,
     /\.delete-btn/,
     /\.drag-handle/,
+    /\.recurring-icon/,
     // Category items (rendered by JavaScript)
     /\.category-item/,
     /\.category-name/,
@@ -196,6 +197,11 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.create-more-option/,
     /\.checkbox-label/,
     /\.priority-star.*svg/,
+    // Recurrence panel elements (modal form)
+    /\.recurrence-/,
+    /\.weekday-checkbox/,
+    /\.monthly-/,
+    /#recurrence/,
 ];
 
 /**

--- a/scripts/setup-hooks.js
+++ b/scripts/setup-hooks.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Setup Git Hooks
+ *
+ * This script is run automatically via `npm install` (via the "prepare" script).
+ * It installs the pre-commit hook to run CSS selector validation.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const GIT_HOOKS_DIR = path.join(__dirname, '..', '.git', 'hooks');
+const PRE_COMMIT_HOOK = path.join(GIT_HOOKS_DIR, 'pre-commit');
+
+const HOOK_CONTENT = `#!/bin/sh
+# Pre-commit hook: Run CSS selector validation
+# Installed by: npm install (via scripts/setup-hooks.js)
+
+# Only run if styles.css or index.html are staged
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if echo "$STAGED_FILES" | grep -qE "(styles\\.css|index\\.html)$"; then
+    echo "Running CSS selector check..."
+
+    # Check if node_modules exists
+    if [ ! -d "node_modules" ]; then
+        echo "Warning: node_modules not found. Run 'npm install' first."
+        echo "Skipping CSS selector check."
+        exit 0
+    fi
+
+    # Run the CSS selector check
+    node scripts/check-css-selectors.js
+
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo "CSS selector check failed!"
+        echo "Please fix the broken selectors before committing."
+        echo ""
+        echo "To add a selector to the ignore list, edit:"
+        echo "  scripts/check-css-selectors.js"
+        echo ""
+        exit 1
+    fi
+
+    echo "CSS selector check passed!"
+fi
+
+exit 0
+`;
+
+function setup() {
+    // Check if .git directory exists
+    if (!fs.existsSync(GIT_HOOKS_DIR)) {
+        console.log('Not a git repository or .git/hooks not found. Skipping hook setup.');
+        return;
+    }
+
+    // Write the pre-commit hook
+    fs.writeFileSync(PRE_COMMIT_HOOK, HOOK_CONTENT, { mode: 0o755 });
+    console.log('Pre-commit hook installed successfully.');
+    console.log('CSS selector validation will run before each commit.');
+}
+
+setup();


### PR DESCRIPTION
## Summary

Add a pre-commit hook that runs CSS selector validation locally before commits, catching issues earlier than the GitHub Actions workflow.

## Changes

- **package.json**: Add dev dependencies (css-tree, jsdom) and npm scripts
- **scripts/setup-hooks.js**: Script to install pre-commit hook (runs on `npm install`)
- **scripts/check-css-selectors.js**: Added recurring icon and recurrence panel patterns
- **.gitignore**: Ignore node_modules and common files

## How it works

1. Run `npm install` once to install dependencies and the pre-commit hook
2. When you commit changes to `styles.css` or `index.html`, the hook runs automatically
3. If broken selectors are found, the commit is blocked with a helpful error message

## Test plan

- [x] `npm install` installs hook successfully
- [x] `npm run check:css` runs validation manually
- [x] Committing CSS changes triggers the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)