### PR TITLE
fix: Save recurrence changes when editing recurring todos

### DIFF
--- a/src/ui/modals/TodoModal.js
+++ b/src/ui/modals/TodoModal.js
@@ -1,5 +1,5 @@
 import { store } from '../../core/store.js'
-import { addTodo, updateTodo, createRecurringTodo, convertToRecurring, getTemplateById } from '../../services/todos.js'
+import { addTodo, updateTodo, createRecurringTodo, convertToRecurring, getTemplateById, updateTemplateRecurrence } from '../../services/todos.js'
 import { buildRecurrenceRule, getNextNOccurrences, formatPreviewDate, calculateFirstOccurrence } from '../../utils/recurrence.js'
 
 /**
@@ -649,9 +649,11 @@ export class TodoModal {
                         // Convert non-recurring todo to recurring
                         const endCondition = this.getEndCondition()
                         await convertToRecurring(editingTodoId, todoData, recurrenceRule, endCondition)
-                    } else {
-                        // Already recurring, just update the todo data (not the recurrence)
+                    } else if (existingTodo && existingTodo.template_id) {
+                        // Already recurring - update both todo data and template recurrence
+                        const endCondition = this.getEndCondition()
                         await updateTodo(editingTodoId, todoData)
+                        await updateTemplateRecurrence(existingTodo.template_id, recurrenceRule, endCondition)
                     }
                 } else {
                     await updateTodo(editingTodoId, todoData)


### PR DESCRIPTION
## Summary
- Adds `updateTemplateRecurrence()` function to update a template's recurrence rule
- Updates `TodoModal.submit()` to save recurrence changes for existing recurring todos

## Problem
When editing an existing recurring todo and changing the recurrence settings (e.g., selecting different weekdays for a weekly recurrence), the changes were not being saved. The todo data was updated, but the template's recurrence rule remained unchanged. When reopening the edit dialog, the old settings would appear.

## Solution
When editing a recurring todo (one that has a `template_id`), we now also call `updateTemplateRecurrence()` to save the updated recurrence rule and end conditions to the template.

## Test plan
- [ ] Create a weekly recurring todo on Monday
- [ ] Edit it and change to Tuesday/Thursday
- [ ] Save and verify the change persists
- [ ] Reopen edit dialog and verify Tuesday/Thursday are selected
- [ ] Test changing interval (e.g., every 2 weeks instead of every week)
- [ ] Test changing end conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)