### PR TITLE
feat: Add Weekdays and Weekends recurrence presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,6 +341,8 @@
                             <select id="modalRepeatSelect" class="modal-sidebar-select" aria-label="Repeat">
                                 <option value="none">Does not repeat</option>
                                 <option value="daily">Daily</option>
+                                <option value="weekdays">Weekdays (Mon-Fri)</option>
+                                <option value="weekends">Weekends (Sat-Sun)</option>
                                 <option value="weekly">Weekly</option>
                                 <option value="monthly">Monthly</option>
                                 <option value="yearly">Yearly</option>


### PR DESCRIPTION
## Summary
Adds two new convenience options in the repeat dropdown:
- **Weekdays (Mon-Fri)**: Auto-selects Monday through Friday
- **Weekends (Sat-Sun)**: Auto-selects Saturday and Sunday

## Implementation
- These are stored internally as `weekly` type with the appropriate weekdays array
- When loading an existing template, the UI detects if weekdays match exactly and shows the correct preset in the dropdown
- User can still manually adjust weekday checkboxes after selecting a preset

## Test plan
- [ ] Select "Weekdays (Mon-Fri)" - verify M-F checkboxes are auto-checked
- [ ] Select "Weekends (Sat-Sun)" - verify Sat/Sun checkboxes are auto-checked  
- [ ] Save a weekdays recurring todo
- [ ] Edit it - verify "Weekdays (Mon-Fri)" is shown in dropdown
- [ ] Save a weekends recurring todo
- [ ] Edit it - verify "Weekends (Sat-Sun)" is shown in dropdown
- [ ] Change from weekdays preset to manually uncheck one day
- [ ] Edit - verify it shows "Weekly" instead of preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)