### PR TITLE
fix: Persist selected Area across page reloads

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ import {
 import { exportTodos } from './src/services/export.js'
 import { loadTodos, addTodo, toggleTodo, deleteTodo, getFilteredTodos, getGtdCount } from './src/services/todos.js'
 import { loadProjects, addProject, deleteProject, selectProject } from './src/services/projects.js'
-import { loadAreas, addArea, selectArea, selectAreaByShortcut } from './src/services/areas.js'
+import { loadAreas, addArea, selectArea, selectAreaByShortcut, restoreSelectedArea } from './src/services/areas.js'
 import { loadCategories } from './src/services/categories.js'
 import { loadContexts } from './src/services/contexts.js'
 import { loadPriorities } from './src/services/priorities.js'
@@ -525,6 +525,9 @@ class TodoApp {
             loadProjects(),
             loadTodos()
         ])
+
+        // Restore persisted UI state
+        restoreSelectedArea()
 
         // Load non-essential items without waiting
         loadThemeFromDatabase()

--- a/src/services/areas.js
+++ b/src/services/areas.js
@@ -177,7 +177,30 @@ export async function reorderAreas(orderedIds) {
  */
 export function selectArea(areaId) {
     store.set('selectedAreaId', areaId)
+    // Persist selection to localStorage
+    localStorage.setItem('selectedAreaId', areaId)
     events.emit(Events.VIEW_CHANGED)
+}
+
+/**
+ * Restore selected area from localStorage
+ * Should be called after areas are loaded
+ */
+export function restoreSelectedArea() {
+    const savedAreaId = localStorage.getItem('selectedAreaId')
+    if (!savedAreaId) return
+
+    const areas = store.get('areas')
+
+    // Validate the saved area still exists
+    if (savedAreaId === 'all' || savedAreaId === 'unassigned') {
+        store.set('selectedAreaId', savedAreaId)
+    } else if (areas.some(a => a.id === savedAreaId)) {
+        store.set('selectedAreaId', savedAreaId)
+    } else {
+        // Saved area no longer exists, clear localStorage
+        localStorage.removeItem('selectedAreaId')
+    }
 }
 
 /**

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -97,6 +97,8 @@ export async function signup(email, password) {
 export async function logout() {
     await supabase.auth.signOut()
     sessionStorage.removeItem('_ep')
+    // Clear persisted UI state
+    localStorage.removeItem('selectedAreaId')
     store.reset()
     events.emit(Events.AUTH_LOGOUT)
 }


### PR DESCRIPTION
## Summary
The selected area is now saved to localStorage and restored when the page reloads.

## Changes
- `src/services/areas.js`: 
  - `selectArea()` now saves to localStorage
  - Added `restoreSelectedArea()` to restore saved selection
- `app.js`: Calls `restoreSelectedArea()` after loading data
- `src/services/auth.js`: `logout()` clears the saved selection

## Behavior
- Selecting an area persists it to localStorage
- On page reload, the saved area is restored
- If the saved area no longer exists (deleted), falls back to default
- Logging out clears the saved selection

## Test plan
- [ ] Select a specific area
- [ ] Reload the page
- [ ] Verify the same area is still selected
- [ ] Select "Unassigned" and reload - verify it persists
- [ ] Delete the selected area and reload - verify it falls back to "All Areas"
- [ ] Logout and login - verify it starts fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)