### PR TITLE
Fix Manage Projects modal items not displaying content (fixes #213)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1686,7 +1686,8 @@ body.sidebar-resizing * {
     flex-shrink: 0;
 }
 
-.manage-projects-color {
+.manage-projects-color,
+.manage-projects-item input[type="color"].manage-projects-color {
     width: 24px;
     height: 24px;
     padding: 0;


### PR DESCRIPTION
## Summary
Fixes the Manage Projects modal where only the drag handle and color picker were visible, while project names, descriptions, area dropdowns, and action buttons were hidden.

## Problem
The generic `.modal-form input` CSS rule (line 2038) was applying `width: 100%` to all inputs inside modals. This selector has higher specificity (0,1,1) than `.manage-projects-color` (0,1,0), causing the color picker input to expand to full width instead of the intended 24x24px size. This pushed all other elements in the flex container out of the visible area.

## Solution
Added a higher-specificity selector `.manage-projects-item input[type="color"].manage-projects-color` (specificity 0,2,2) to ensure the color picker input properly respects the intended 24px × 24px dimensions regardless of the modal form's generic input styles.

## Changes
- `styles.css`: Added more specific selector for the color picker input to override modal form styles

## Testing
- [x] CSS validation check passes (`npm run check:css`)
- [x] Pre-commit hooks pass
- [ ] Manual testing: Verify color picker displays as 24x24 circle
- [ ] Manual testing: Verify project name, description, area dropdown, and buttons are visible
- [ ] Manual testing: Test in both light and dark themes

Fixes #213

Generated with [Claude Code](https://claude.com/claude-code)