### PR TITLE
fix: Scheduled view count now matches displayed items

### DIFF
--- a/src/services/todos.js
+++ b/src/services/todos.js
@@ -462,8 +462,8 @@ export function getGtdCount(status) {
         return todos.filter(t => t.gtd_status !== 'done').length
     }
     if (status === 'scheduled') {
-        // Count all non-done items with a due date
-        return todos.filter(t => t.due_date && t.gtd_status !== 'done').length
+        // Count items with 'scheduled' GTD status (matches getFilteredTodos display logic)
+        return todos.filter(t => t.gtd_status === 'scheduled').length
     }
     return todos.filter(t => t.gtd_status === status).length
 }


### PR DESCRIPTION
## Summary
Fixes mismatch between Scheduled count badge and actually displayed items.

## Problem
- Navigation showed "Scheduled: 10" 
- But only 3 items were displayed in the view

The count was using `t.due_date && t.gtd_status !== 'done'` (all items with due dates), while the display filter used `t.gtd_status === 'scheduled'`.

## Solution
Updated `getGtdCount()` to use the same filter as `getFilteredTodos()`:
```javascript
// Before (wrong)
return todos.filter(t => t.due_date && t.gtd_status !== 'done').length

// After (correct)
return todos.filter(t => t.gtd_status === 'scheduled').length
```

## Files Changed
- `src/services/todos.js` - Fixed `getGtdCount()` for scheduled status

Generated with [Claude Code](https://claude.com/claude-code)