### PR TITLE
fix: Scheduled view shows all items with due dates

### DIFF
--- a/src/services/todos.js
+++ b/src/services/todos.js
@@ -405,8 +405,8 @@ export function getFilteredTodos() {
 
     // Filter by GTD status
     if (state.selectedGtdStatus === 'scheduled') {
-        // Show items with 'scheduled' GTD status, sorted by due date
-        filtered = filtered.filter(t => t.gtd_status === 'scheduled')
+        // Show all items with a due date (excluding done) - this is a virtual/computed view
+        filtered = filtered.filter(t => t.due_date && t.gtd_status !== 'done')
         // Sort by due date (earliest first), items without dates go last
         return filtered.slice().sort((a, b) => {
             if (!a.due_date && !b.due_date) return 0
@@ -462,8 +462,8 @@ export function getGtdCount(status) {
         return todos.filter(t => t.gtd_status !== 'done').length
     }
     if (status === 'scheduled') {
-        // Count items with 'scheduled' GTD status (matches getFilteredTodos display logic)
-        return todos.filter(t => t.gtd_status === 'scheduled').length
+        // Count all items with a due date (excluding done) - matches getFilteredTodos display logic
+        return todos.filter(t => t.due_date && t.gtd_status !== 'done').length
     }
     return todos.filter(t => t.gtd_status === status).length
 }


### PR DESCRIPTION
## Summary
Changes Scheduled from a GTD status filter to a computed view showing all items with due dates.

## Problem
- Items with due dates but different GTD statuses (e.g., 'next_action') weren't showing in Scheduled view
- Only items with `gtd_status === 'scheduled'` appeared
- This didn't match user expectation: "if it has a date, it's scheduled"

## Solution
Made Scheduled a virtual/computed view (like "All") that shows items based on having a `due_date`:

```javascript
// Both count and display now use:
filtered.filter(t => t.due_date && t.gtd_status !== 'done')
```

## Files Changed
- `src/services/todos.js` - Updated both `getFilteredTodos()` and `getGtdCount()` for scheduled

Generated with [Claude Code](https://claude.com/claude-code)