### PR TITLE
feat: Add multi-select capability for todos with bulk actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,34 @@
                         <span class="area-header-name"></span>
                     </div>
 
+                    <!-- Selection Bar (appears when todos are selected) -->
+                    <div id="selectionBar" class="selection-bar">
+                        <div class="selection-bar-left">
+                            <span id="selectionCount" class="selection-count">0 selected</span>
+                            <button id="selectAllBtn" class="selection-bar-btn selection-bar-btn-secondary">Select All</button>
+                            <button id="clearSelectionBtn" class="selection-bar-btn selection-bar-btn-secondary">Clear</button>
+                        </div>
+                        <div class="selection-bar-right">
+                            <button id="completeSelectedBtn" class="selection-bar-btn selection-bar-btn-success">Complete</button>
+                            <button id="deleteSelectedBtn" class="selection-bar-btn selection-bar-btn-danger">Delete</button>
+                            <select id="selectionGtdStatusSelect" class="selection-bar-select" aria-label="Change GTD Status">
+                                <option value="">Set Status...</option>
+                                <option value="inbox">Inbox</option>
+                                <option value="next_action">Next Action</option>
+                                <option value="scheduled">Scheduled</option>
+                                <option value="waiting_for">Waiting For</option>
+                                <option value="someday_maybe">Someday/Maybe</option>
+                                <option value="done">Done</option>
+                            </select>
+                            <select id="selectionProjectSelect" class="selection-bar-select" aria-label="Change Project">
+                                <option value="">Move to Project...</option>
+                            </select>
+                            <select id="selectionPrioritySelect" class="selection-bar-select" aria-label="Change Priority">
+                                <option value="">Set Priority...</option>
+                            </select>
+                        </div>
+                    </div>
+
                     <ul id="todoList" class="todo-list"></ul>
                 </div>
             </div>

--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -116,6 +116,7 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     // Todo items (rendered by JavaScript)
     /\.todo-item/,
     /\.todo-checkbox/,
+    /\.todo-select-checkbox/,
     /\.todo-content/,
     /\.todo-text/,
     /\.todo-comment/,
@@ -220,6 +221,13 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.modal-sidebar-divider/,
     /\.modal-tab/,
     /\.modal-tabs/,
+    // Selection bar (rendered by JavaScript)
+    /\.selection-bar/,
+    /\.selection-count/,
+    /\.selection-bar-left/,
+    /\.selection-bar-right/,
+    /\.selection-bar-btn/,
+    /\.selection-bar-select/,
 ];
 
 /**

--- a/src/core/store.js
+++ b/src/core/store.js
@@ -29,7 +29,11 @@ class Store {
             // UI state
             showProjectsView: false,
             editingTodoId: null,
-            searchQuery: ''
+            searchQuery: '',
+
+            // Multi-select state
+            selectedTodoIds: new Set(),
+            lastSelectedTodoId: null // For shift-click range selection
         }
 
         this._listeners = new Map()
@@ -135,7 +139,9 @@ class Store {
             selectedGtdStatus: 'inbox',
             showProjectsView: false,
             editingTodoId: null,
-            searchQuery: ''
+            searchQuery: '',
+            selectedTodoIds: new Set(),
+            lastSelectedTodoId: null
         }
     }
 }

--- a/src/ui/SelectionBar.js
+++ b/src/ui/SelectionBar.js
@@ -1,0 +1,224 @@
+import { store } from '../core/store.js'
+import { escapeHtml, validateColor } from '../utils/security.js'
+import {
+    bulkDeleteTodos,
+    bulkUpdateTodosStatus,
+    bulkUpdateTodosProject,
+    bulkUpdateTodosPriority,
+    selectAllTodos,
+    clearTodoSelection,
+    getFilteredTodos
+} from '../services/todos.js'
+
+/**
+ * Get human-readable label for a GTD status
+ * @param {string} status - GTD status
+ * @returns {string} Human-readable label
+ */
+function getGtdStatusLabel(status) {
+    const labels = {
+        'inbox': 'Inbox',
+        'next_action': 'Next',
+        'scheduled': 'Scheduled',
+        'waiting_for': 'Waiting',
+        'someday_maybe': 'Someday',
+        'done': 'Done'
+    }
+    return labels[status] || status
+}
+
+/**
+ * Initialize the selection bar with event listeners
+ * @param {Object} elements - DOM elements for the selection bar
+ */
+export function initSelectionBar(elements) {
+    const {
+        selectionBar,
+        selectionCount,
+        selectAllBtn,
+        clearSelectionBtn,
+        deleteSelectedBtn,
+        completeSelectedBtn,
+        gtdStatusSelect,
+        projectSelect,
+        prioritySelect
+    } = elements
+
+    // Select All button
+    selectAllBtn.addEventListener('click', () => {
+        const filteredTodos = getFilteredTodos()
+        const visibleIds = filteredTodos.map(t => t.id)
+        selectAllTodos(visibleIds)
+    })
+
+    // Clear Selection button
+    clearSelectionBtn.addEventListener('click', () => {
+        clearTodoSelection()
+    })
+
+    // Delete Selected button
+    deleteSelectedBtn.addEventListener('click', async () => {
+        const selectedIds = Array.from(store.get('selectedTodoIds'))
+        if (selectedIds.length === 0) return
+
+        const confirmed = confirm(`Delete ${selectedIds.length} selected item(s)?`)
+        if (!confirmed) return
+
+        deleteSelectedBtn.disabled = true
+        deleteSelectedBtn.textContent = 'Deleting...'
+
+        try {
+            await bulkDeleteTodos(selectedIds)
+        } catch (error) {
+            console.error('Error deleting selected todos:', error)
+            alert('Failed to delete some items')
+        } finally {
+            deleteSelectedBtn.disabled = false
+            deleteSelectedBtn.textContent = 'Delete'
+        }
+    })
+
+    // Complete Selected button
+    completeSelectedBtn.addEventListener('click', async () => {
+        const selectedIds = Array.from(store.get('selectedTodoIds'))
+        if (selectedIds.length === 0) return
+
+        completeSelectedBtn.disabled = true
+        completeSelectedBtn.textContent = 'Completing...'
+
+        try {
+            await bulkUpdateTodosStatus(selectedIds, 'done')
+        } catch (error) {
+            console.error('Error completing selected todos:', error)
+            alert('Failed to complete some items')
+        } finally {
+            completeSelectedBtn.disabled = false
+            completeSelectedBtn.textContent = 'Complete'
+        }
+    })
+
+    // GTD Status select
+    gtdStatusSelect.addEventListener('change', async () => {
+        const newStatus = gtdStatusSelect.value
+        if (!newStatus) return
+
+        const selectedIds = Array.from(store.get('selectedTodoIds'))
+        if (selectedIds.length === 0) return
+
+        try {
+            await bulkUpdateTodosStatus(selectedIds, newStatus)
+        } catch (error) {
+            console.error('Error updating status:', error)
+            alert('Failed to update status')
+        }
+
+        gtdStatusSelect.value = ''
+    })
+
+    // Project select
+    projectSelect.addEventListener('change', async () => {
+        const newProjectId = projectSelect.value
+        const selectedIds = Array.from(store.get('selectedTodoIds'))
+        if (selectedIds.length === 0) return
+
+        try {
+            await bulkUpdateTodosProject(selectedIds, newProjectId || null)
+        } catch (error) {
+            console.error('Error updating project:', error)
+            alert('Failed to update project')
+        }
+
+        projectSelect.value = ''
+    })
+
+    // Priority select
+    prioritySelect.addEventListener('change', async () => {
+        const newPriorityId = prioritySelect.value
+        const selectedIds = Array.from(store.get('selectedTodoIds'))
+        if (selectedIds.length === 0) return
+
+        try {
+            await bulkUpdateTodosPriority(selectedIds, newPriorityId || null)
+        } catch (error) {
+            console.error('Error updating priority:', error)
+            alert('Failed to update priority')
+        }
+
+        prioritySelect.value = ''
+    })
+
+    // Subscribe to selection changes
+    store.subscribe('selectedTodoIds', (selectedIds) => {
+        updateSelectionBar(elements, selectedIds)
+    })
+
+    // Initial state
+    updateSelectionBar(elements, store.get('selectedTodoIds'))
+}
+
+/**
+ * Update the selection bar visibility and content
+ * @param {Object} elements - DOM elements
+ * @param {Set} selectedIds - Currently selected todo IDs
+ */
+function updateSelectionBar(elements, selectedIds) {
+    const { selectionBar, selectionCount } = elements
+    const count = selectedIds ? selectedIds.size : 0
+
+    if (count > 0) {
+        selectionBar.classList.add('visible')
+        selectionCount.textContent = `${count} selected`
+    } else {
+        selectionBar.classList.remove('visible')
+    }
+}
+
+/**
+ * Update the project select dropdown in selection bar
+ * @param {HTMLSelectElement} selectElement - The project select element
+ */
+export function updateSelectionBarProjectSelect(selectElement) {
+    const projects = store.get('projects') || []
+
+    // Keep the first option (placeholder)
+    selectElement.innerHTML = '<option value="">Move to Project...</option>'
+
+    // Add "No Project" option
+    const noProjectOption = document.createElement('option')
+    noProjectOption.value = ''
+    noProjectOption.textContent = 'No Project'
+    selectElement.appendChild(noProjectOption)
+
+    // Add project options
+    projects.forEach(project => {
+        const option = document.createElement('option')
+        option.value = project.id
+        option.textContent = project.name
+        selectElement.appendChild(option)
+    })
+}
+
+/**
+ * Update the priority select dropdown in selection bar
+ * @param {HTMLSelectElement} selectElement - The priority select element
+ */
+export function updateSelectionBarPrioritySelect(selectElement) {
+    const priorities = store.get('priorities') || []
+
+    // Keep the first option (placeholder)
+    selectElement.innerHTML = '<option value="">Set Priority...</option>'
+
+    // Add "No Priority" option
+    const noPriorityOption = document.createElement('option')
+    noPriorityOption.value = ''
+    noPriorityOption.textContent = 'No Priority'
+    selectElement.appendChild(noPriorityOption)
+
+    // Add priority options
+    priorities.forEach(priority => {
+        const option = document.createElement('option')
+        option.value = priority.id
+        option.textContent = priority.name
+        selectElement.appendChild(option)
+    })
+}

--- a/styles.css
+++ b/styles.css
@@ -4684,3 +4684,209 @@ body.sidebar-resizing * {
     padding: 4px 10px;
     font-size: 12px;
 }
+
+/* ===========================================
+   Multi-Select / Selection Bar Styles
+   =========================================== */
+
+/* Selection checkbox on todo items */
+.todo-select-checkbox {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+    accent-color: var(--ios-blue);
+    flex-shrink: 0;
+    margin-right: 4px;
+    opacity: 0.5;
+    transition: opacity 0.2s ease;
+}
+
+.todo-item:hover .todo-select-checkbox,
+.todo-item.selected .todo-select-checkbox {
+    opacity: 1;
+}
+
+/* Selected todo item styling */
+.todo-item.selected {
+    background: rgba(0, 122, 255, 0.1);
+    border-left-color: var(--ios-blue) !important;
+    box-shadow: inset 0 0 0 2px rgba(0, 122, 255, 0.15);
+}
+
+.todo-item.selected:hover {
+    background: rgba(0, 122, 255, 0.15);
+}
+
+/* Selection Bar - Floating action bar */
+.selection-bar {
+    display: none;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--ios-material-thick);
+    backdrop-filter: blur(var(--ios-blur-regular));
+    -webkit-backdrop-filter: blur(var(--ios-blur-regular));
+    border-radius: 10px;
+    padding: 12px 16px;
+    margin-bottom: 12px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    border: 1px solid var(--ios-separator);
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
+    animation: slideDown 0.2s ease-out;
+}
+
+.selection-bar.visible {
+    display: flex;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.selection-bar-left,
+.selection-bar-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.selection-count {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--ios-label);
+    padding: 0 8px;
+    min-width: 80px;
+}
+
+.selection-bar-btn {
+    padding: 8px 14px;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+}
+
+.selection-bar-btn-secondary {
+    background: var(--ios-gray5);
+    color: var(--ios-label);
+}
+
+.selection-bar-btn-secondary:hover {
+    background: var(--ios-gray4);
+}
+
+.selection-bar-btn-success {
+    background: #34c759;
+    color: white;
+}
+
+.selection-bar-btn-success:hover {
+    background: #2fb150;
+}
+
+.selection-bar-btn-danger {
+    background: var(--ios-red);
+    color: white;
+}
+
+.selection-bar-btn-danger:hover {
+    background: #e32d22;
+}
+
+.selection-bar-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.selection-bar-select {
+    padding: 8px 12px;
+    border: 1px solid var(--ios-separator);
+    border-radius: 6px;
+    font-size: 13px;
+    background: var(--ios-bg-secondary);
+    color: var(--ios-label);
+    cursor: pointer;
+    min-width: 140px;
+}
+
+.selection-bar-select:hover {
+    border-color: var(--ios-gray3);
+}
+
+.selection-bar-select:focus {
+    outline: none;
+    border-color: var(--ios-blue);
+}
+
+/* Dark theme adjustments for selection */
+[data-theme="dark"] .todo-item.selected {
+    background: rgba(10, 132, 255, 0.2);
+    box-shadow: inset 0 0 0 2px rgba(10, 132, 255, 0.2);
+}
+
+[data-theme="dark"] .todo-item.selected:hover {
+    background: rgba(10, 132, 255, 0.25);
+}
+
+[data-theme="dark"] .selection-bar {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .selection-bar-btn-secondary {
+    background: var(--ios-gray4);
+    color: var(--ios-label);
+}
+
+[data-theme="dark"] .selection-bar-btn-secondary:hover {
+    background: var(--ios-gray3);
+}
+
+/* Clear theme adjustments for selection */
+[data-theme="clear"] .todo-item.selected {
+    background: rgba(28, 28, 30, 0.08);
+    border-left-color: var(--ios-blue) !important;
+    box-shadow: inset 0 0 0 2px rgba(28, 28, 30, 0.1);
+}
+
+[data-theme="clear"] .todo-item.selected:hover {
+    background: rgba(28, 28, 30, 0.12);
+}
+
+/* Compact density adjustments for selection */
+[data-density="compact"] .selection-bar {
+    padding: 8px 12px;
+    gap: 8px;
+}
+
+[data-density="compact"] .selection-bar-btn {
+    padding: 6px 10px;
+    font-size: 12px;
+}
+
+[data-density="compact"] .selection-bar-select {
+    padding: 6px 10px;
+    font-size: 12px;
+}
+
+[data-density="compact"] .selection-count {
+    font-size: 13px;
+}
+
+[data-density="compact"] .todo-select-checkbox {
+    width: 16px;
+    height: 16px;
+}


### PR DESCRIPTION
## Summary
- Add multi-select capability allowing users to select multiple todos at once
- Implement floating selection bar with bulk action buttons
- Support Shift+Click for range selection and Cmd/Ctrl+Click for toggle selection
- Add bulk actions: Delete, Complete, Change GTD Status, Project, and Priority

## Features
- **Selection UI**: Selection checkbox appears on each todo item, with visual highlight for selected items
- **Range Selection**: Hold Shift and click to select a range of todos
- **Multi-Select Toggle**: Hold Cmd/Ctrl and click to toggle individual selections
- **Selection Bar**: Floating action bar appears when items are selected, showing count and action buttons
- **Bulk Actions**:
  - Delete selected todos
  - Mark selected as complete
  - Change GTD status for all selected
  - Move selected to a project
  - Set priority for all selected
- **Keyboard Shortcut**: Press Escape to clear selection
- **Auto-Clear**: Selection clears when navigating between views

## Test plan
- [ ] Click selection checkbox on a todo - it should become selected with visual highlight
- [ ] Hold Shift and click another todo - range should be selected
- [ ] Selection bar should appear showing count of selected items
- [ ] Click "Select All" - all visible todos should be selected
- [ ] Click "Clear" - all selections should be cleared
- [ ] Test Delete button - should remove all selected todos after confirmation
- [ ] Test Complete button - should mark all as done
- [ ] Test GTD Status dropdown - should update status for all selected
- [ ] Test Project dropdown - should assign project to all selected
- [ ] Test Priority dropdown - should set priority for all selected
- [ ] Press Escape - selection should clear
- [ ] Navigate to different GTD view - selection should clear
- [ ] Test across different themes (glass, dark, clear)
- [ ] Test with compact density mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)