### PR TITLE
fix: Update changelog link to point to latest release

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
                                 <button id="logoutBtn" class="toolbar-dropdown-item toolbar-dropdown-item-danger" role="menuitem">Logout</button>
                                 <div class="toolbar-dropdown-divider"></div>
                                 <a href="https://github.com/RadekCap/todolist" target="_blank" rel="noopener noreferrer" class="toolbar-dropdown-item toolbar-dropdown-link" role="menuitem">GitHub</a>
-                                <a href="https://github.com/RadekCap/todolist/blob/main/VERSION.md" target="_blank" rel="noopener noreferrer" class="toolbar-dropdown-item toolbar-dropdown-link" role="menuitem">Changelog</a>
+                                <a href="https://github.com/RadekCap/todolist/releases/latest" target="_blank" rel="noopener noreferrer" class="toolbar-dropdown-item toolbar-dropdown-link" role="menuitem">Changelog</a>
                                 <a href="https://github.com/RadekCap/todolist/issues/new?labels=feature-request" target="_blank" rel="noopener noreferrer" class="toolbar-dropdown-item toolbar-dropdown-link" role="menuitem">Request Feature</a>
                                 <a href="https://github.com/RadekCap/todolist/issues/new?labels=bug" target="_blank" rel="noopener noreferrer" class="toolbar-dropdown-item toolbar-dropdown-link" role="menuitem">Report Issue</a>
                             </div>


### PR DESCRIPTION
## Summary
- Changed the changelog menu link from VERSION.md to `/releases/latest`
- The link now automatically redirects to the most recent GitHub release
- No manual updates needed when new versions are published

## Test plan
- [ ] Click "Changelog" in the menu dropdown
- [ ] Verify it opens the latest release page (currently v2.1.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)