### PR TITLE
Fix: Show todos without project in all area views (fixes #222)

### DIFF
--- a/src/services/todos.js
+++ b/src/services/todos.js
@@ -582,7 +582,7 @@ export function getFilteredTodos() {
     }
 
     // Filter by area (through project.area_id)
-    // Inbox items are always shown regardless of area selection
+    // Inbox items and items without a project are always shown regardless of area selection
     if (state.selectedAreaId !== 'all') {
         filtered = filtered.filter(t => {
             // Inbox items are always visible
@@ -590,11 +590,16 @@ export function getFilteredTodos() {
                 return true
             }
 
+            // Todos without a project are always visible (they're unassigned to any area)
+            if (!t.project_id) {
+                return true
+            }
+
             // Get the project's area
-            const project = t.project_id ? state.projects.find(p => p.id === t.project_id) : null
+            const project = state.projects.find(p => p.id === t.project_id)
 
             if (state.selectedAreaId === 'unassigned') {
-                // Show items where the project has no area, or item has no project
+                // Show items where the project has no area
                 return !project || project.area_id === null
             } else {
                 // Show items where the project belongs to the selected area


### PR DESCRIPTION
## Summary
Fixes a bug where todos with `project_id = null` were not visible in the UI when an area filter was active.

## Problem
Todos without a project assignment (project_id = null) were incorrectly filtered out when viewing a specific area. The area filter required todos to have a project that belongs to the selected area, which excluded todos without any project assignment entirely.

As reported in #222, a todo (id=392) with `project_id = null` was not visible, while an otherwise identical todo (id=394) with a project assigned was visible.

## Solution
Modified the area filtering logic in `getFilteredTodos()` to treat todos without a project similarly to inbox items - they are now always visible regardless of area selection.

The fix adds an early return check for todos without a `project_id`, ensuring they appear in:
- **All Areas** view (already worked, no filter applied)
- **Unassigned** view (already worked via `!project` check)
- **Specific area** views (now fixed - previously hidden)

## Changes
- `src/services/todos.js`: Added early return for todos with null `project_id` in area filter
- Updated comment to reflect the new behavior

## Testing
- [x] Todos without a project now appear in all area views
- [x] Inbox items continue to be visible in all views
- [x] Assigned todos still filter correctly by their project's area
- [x] "Unassigned" view continues to show todos without projects and projects without areas

Fixes #222

Generated with [Claude Code](https://claude.com/claude-code)