### PR TITLE
fix: Safari iOS display bug with vertical text (fixes #224)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -910,6 +910,7 @@ body.sidebar-resizing * {
     margin-bottom: 10px;
     border-radius: 8px;
     display: flex;
+    flex-wrap: nowrap; /* Prevent Safari iOS from incorrectly wrapping flex items */
     align-items: center;
     gap: 12px;
     transition: background 0.3s, transform 0.3s, opacity 0.3s, box-shadow 0.3s;
@@ -958,6 +959,7 @@ body.sidebar-resizing * {
     opacity: 0.6;
     transition: opacity 0.2s, color 0.2s, transform 0.2s, background-color 0.2s;
     border-radius: 4px;
+    flex-shrink: 0; /* Prevent Safari iOS from shrinking */
 }
 
 .drag-handle:hover {
@@ -982,6 +984,7 @@ body.sidebar-resizing * {
     height: 20px;
     cursor: pointer;
     accent-color: var(--accent-color);
+    flex-shrink: 0; /* Prevent Safari iOS from shrinking */
 }
 
 .todo-content {
@@ -1020,6 +1023,7 @@ body.sidebar-resizing * {
     font-weight: 600;
     color: white;
     white-space: nowrap;
+    flex-shrink: 0; /* Prevent Safari iOS from shrinking badges causing vertical text */
 }
 
 .todo-date {
@@ -1030,6 +1034,7 @@ body.sidebar-resizing * {
     color: #666;
     background: #f0f0f0;
     white-space: nowrap;
+    flex-shrink: 0; /* Prevent Safari iOS from shrinking badges causing vertical text */
 }
 
 .todo-date.overdue {
@@ -1049,6 +1054,7 @@ body.sidebar-resizing * {
     font-weight: 600;
     color: white;
     white-space: nowrap;
+    flex-shrink: 0; /* Prevent Safari iOS from shrinking badges causing vertical text */
 }
 
 .delete-btn {
@@ -1060,6 +1066,7 @@ body.sidebar-resizing * {
     cursor: pointer;
     font-size: 14px;
     transition: background 0.3s;
+    flex-shrink: 0; /* Prevent Safari iOS from shrinking buttons */
 }
 
 .delete-btn:hover {
@@ -2790,6 +2797,7 @@ body.sidebar-resizing * {
     font-size: 12px;
     font-weight: 600;
     white-space: nowrap;
+    flex-shrink: 0; /* Prevent Safari iOS from shrinking badges causing vertical text */
 }
 
 .todo-gtd-badge.inbox {
@@ -2831,6 +2839,7 @@ body.sidebar-resizing * {
     background: #eceff1;
     color: #546e7a;
     white-space: nowrap;
+    flex-shrink: 0; /* Prevent Safari iOS from shrinking badges causing vertical text */
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
Fixes a Safari iOS display bug where text in todo item badges (GTD status, priority, category, etc.) was being rendered vertically instead of horizontally on narrow mobile screens.

## Problem
On Safari iOS, the flexbox layout of todo items was causing text badges to render with each character on a separate line due to improper flex item shrinking behavior.

![Screenshot from issue](https://github.com/user-attachments/assets/418b8449-0f92-4c17-9457-1430d6382c8b)

## Solution
Applied two CSS fixes to prevent Safari iOS from incorrectly handling flex items:

1. **Added `flex-wrap: nowrap`** to `.todo-item` to explicitly prevent flex items from wrapping incorrectly
2. **Added `flex-shrink: 0`** to all flex children that should maintain their size:
   - Todo badges (GTD status, category, priority, context, date)
   - Checkbox and drag handle elements
   - Delete button

## Changes
- `styles.css`: Added `flex-wrap: nowrap` to `.todo-item`
- `styles.css`: Added `flex-shrink: 0` to:
  - `.todo-gtd-badge`
  - `.todo-category-badge`
  - `.todo-priority-badge`
  - `.todo-context-badge`
  - `.todo-date`
  - `.todo-checkbox`
  - `.drag-handle`
  - `.delete-btn`

## Testing
- [x] CSS selector validation passed
- [x] No existing tests broken
- [ ] Manual testing on Safari iOS recommended

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)