### PR TITLE
fix: Safari iOS vertical text display bug (fixes #227)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -722,6 +722,7 @@ body.sidebar-resizing * {
     flex: 1;
     min-width: 0;
     scrollbar-gutter: stable;
+    overflow-x: hidden; /* Prevent horizontal overflow that can cause Safari iOS layout issues */
 }
 
 /* Area Header - Shows current area with color indicator */
@@ -836,6 +837,7 @@ body.sidebar-resizing * {
 .todo-list {
     list-style: none;
     min-height: 360px;
+    width: 100%; /* Ensure full width for Safari iOS layout calculation */
 }
 
 /* Scheduled view section headers */
@@ -988,15 +990,18 @@ body.sidebar-resizing * {
 }
 
 .todo-content {
-    flex: 1;
+    flex: 1 1 0%; /* Explicit flex-basis of 0% helps Safari iOS calculate width correctly */
     min-width: 0;
+    overflow: hidden; /* Prevent Safari iOS from incorrectly calculating text layout */
 }
 
 .todo-text {
     color: #333;
     font-size: 16px;
     word-break: break-word;
+    overflow-wrap: break-word; /* Ensure proper word wrapping on Safari iOS */
     cursor: pointer;
+    display: block; /* Ensure block display to prevent inline flex issues on Safari iOS */
 }
 
 .todo-comment {
@@ -1005,6 +1010,8 @@ body.sidebar-resizing * {
     margin-top: 4px;
     line-height: 1.4;
     word-break: break-word;
+    overflow-wrap: break-word; /* Ensure proper word wrapping on Safari iOS */
+    display: block; /* Ensure block display to prevent inline flex issues on Safari iOS */
 }
 
 .todo-item.completed .todo-text {


### PR DESCRIPTION
## Summary
Fixes a Safari iOS display bug where todo text was being rendered vertically (one character per line) instead of horizontally.

## Problem
Safari iOS has a flexbox bug where it can miscalculate flex item widths, especially when combined with `min-width: 0`. This causes text to render in an extremely narrow column, appearing as if each character is on its own line.

Screenshots from issue #227:
![Screenshot 1](https://github.com/user-attachments/assets/5907decf-e9ef-441f-aa22-326fe2d6e02a)
![Screenshot 3](https://github.com/user-attachments/assets/98ef0b8b-731a-4992-93df-924f69a3c756)

## Solution
Applied multiple CSS fixes to ensure Safari iOS correctly calculates element widths:

1. **`.content`**: Added `overflow-x: hidden` to prevent horizontal overflow that triggers layout issues
2. **`.todo-list`**: Added `width: 100%` to ensure proper layout calculation
3. **`.todo-content`**: Changed `flex: 1` to `flex: 1 1 0%` for explicit flex-basis, added `overflow: hidden`
4. **`.todo-text`**: Added `overflow-wrap: break-word` and `display: block`
5. **`.todo-comment`**: Added `overflow-wrap: break-word` and `display: block`

## Changes
- `styles.css`: Added 8 lines of CSS fixes for Safari iOS layout issues

## Testing
- [x] CSS selector validation passed
- [ ] Manual testing on Safari iOS recommended

Fixes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)