### PR TITLE
Add keyboard shortcuts dialog access via menu and K key

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,7 @@ class TodoApp {
         this.toolbarUserMenu = document.getElementById('toolbarUserMenu')
         this.toolbarUserBtn = document.getElementById('toolbarUserBtn')
         this.settingsBtn = document.getElementById('settingsBtn')
+        this.keyboardShortcutsBtn = document.getElementById('keyboardShortcutsBtn')
         this.refreshBtn = document.getElementById('refreshBtn')
         this.lockBtn = document.getElementById('lockBtn')
         this.logoutBtn = document.getElementById('logoutBtn')
@@ -318,6 +319,11 @@ class TodoApp {
             this.closeToolbarMenu()
             this.openSettingsModal()
         })
+        // Keyboard shortcuts from menu
+        this.keyboardShortcutsBtn.addEventListener('click', () => {
+            this.closeToolbarMenu()
+            this.openKeyboardShortcutsModal()
+        })
         this.closeSettingsModalBtn.addEventListener('click', () => this.closeSettingsModal())
         this.cancelSettingsModalBtn.addEventListener('click', () => this.closeSettingsModal())
         this.settingsModal.addEventListener('click', (e) => {
@@ -508,8 +514,8 @@ class TodoApp {
             this.searchInput.focus()
         }
 
-        // '?' to show keyboard shortcuts help
-        if (e.key === '?' && !isTyping && !modalOpen && !e.ctrlKey && !e.metaKey && !e.altKey && !e.isComposing) {
+        // 'k' or '?' to show keyboard shortcuts help
+        if ((e.key === 'k' || e.key === '?') && !isTyping && !modalOpen && !e.ctrlKey && !e.metaKey && !e.altKey && !e.isComposing) {
             e.preventDefault()
             this.openKeyboardShortcutsModal()
         }

--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@
                             </button>
                             <div class="toolbar-dropdown" id="toolbarDropdown" role="menu">
                                 <button id="settingsBtn" class="toolbar-dropdown-item" role="menuitem">Settings</button>
+                                <button id="keyboardShortcutsBtn" class="toolbar-dropdown-item" role="menuitem">Keyboard Shortcuts</button>
                                 <button id="refreshBtn" class="toolbar-dropdown-item" role="menuitem">Refresh</button>
                                 <button id="lockBtn" class="toolbar-dropdown-item" role="menuitem">Lock</button>
                                 <div class="toolbar-dropdown-divider"></div>
@@ -830,7 +831,7 @@
                         <li><kbd>n</kbd> <span>New Todo</span></li>
                         <li><kbd>/</kbd> <span>Focus Search</span></li>
                         <li><kbd>Esc</kbd> <span>Close Modal / Clear Search</span></li>
-                        <li><kbd>?</kbd> <span>Show This Help</span></li>
+                        <li><kbd>k</kbd> <span>Show This Help</span></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Added a "Keyboard Shortcuts" item to the user dropdown menu (between Settings and Refresh)
- Registered the `K` key as a keyboard shortcut to open the shortcuts help dialog (in addition to existing `?`)
- Updated the shortcuts list in the modal to show `k` instead of `?`

## Test plan
- [ ] Open the user dropdown menu and verify "Keyboard Shortcuts" item appears between Settings and Refresh
- [ ] Click "Keyboard Shortcuts" menu item and verify the shortcuts dialog opens
- [ ] Press `K` key (outside any input field) and verify the shortcuts dialog opens
- [ ] Press `?` key and verify it still opens the dialog (backwards compatible)
- [ ] Verify the dialog shows `k` in the Actions section shortcuts list
- [ ] Verify ESC closes the dialog
- [ ] Test in Chrome, Firefox, Safari, Edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)