### PR TITLE
fix: Redesign toolbar and sidebar buttons for mobile view (fixes #231)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2673,6 +2673,23 @@ body.sidebar-resizing * {
     .modal-form-sidebar {
         grid-template-columns: 1fr;
     }
+
+    .content-toolbar .toolbar-btn.add-todo-btn {
+        padding: 6px 10px;
+        font-size: 12px;
+    }
+
+    .toolbar-areas-label {
+        max-width: 60px;
+    }
+
+    .toolbar-username {
+        max-width: 50px;
+    }
+
+    .toolbar-search {
+        min-width: 60px;
+    }
 }
 
 @media (max-width: 768px) {
@@ -2705,6 +2722,72 @@ body.sidebar-resizing * {
 
     .form-columns {
         flex-direction: column;
+    }
+
+    /* Mobile toolbar layout */
+    .content-toolbar {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .toolbar-spacer {
+        display: none;
+    }
+
+    .content-toolbar .toolbar-btn.add-todo-btn {
+        font-size: 13px;
+        padding: 8px 14px;
+        white-space: nowrap;
+        width: auto;
+        margin-bottom: 0;
+    }
+
+    .toolbar-search {
+        flex: 1 1 auto;
+        min-width: 80px;
+        margin-left: 0;
+    }
+
+    .content-toolbar .toolbar-btn-secondary {
+        padding: 5px 10px;
+        font-size: 12px;
+        margin-right: 0;
+    }
+
+    .toolbar-theme-select,
+    .toolbar-density-select {
+        padding: 5px 8px;
+        font-size: 12px;
+        margin-right: 0;
+    }
+
+    .toolbar-username {
+        max-width: 80px;
+    }
+
+    .toolbar-areas-label {
+        max-width: 90px;
+    }
+
+    /* Mobile sidebar buttons */
+    .add-project-form {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+    }
+
+    .add-project-input {
+        flex: 1;
+        margin-bottom: 0;
+    }
+
+    .add-project-btn {
+        width: auto;
+        flex-shrink: 0;
+    }
+
+    .manage-projects-btn {
+        width: auto;
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixes toolbar overflow on mobile by adding `flex-wrap` and compact button sizing
- Makes sidebar "Add Project" form inline and "Manage Projects" button auto-width
- Adds additional refinements for very narrow screens (400px and below)

## Problem
On mobile screens (768px and below), the content toolbar's 9 items overflow in a single row: the "+ Add Todo" button text wraps to 3 lines, Import is partially visible, and Export/Theme/Density/User menu are pushed off-screen. The sidebar "Add Project" and "Manage Projects" buttons also take excessive vertical space as full-width elements.

## Solution
CSS-only responsive fix using `flex-wrap: wrap` and `gap` on the toolbar (following the existing `.selection-bar` pattern), with compact sizing for buttons, selects, and text labels at mobile breakpoints. No HTML or JavaScript changes needed.

## Changes
- **768px breakpoint**: Toolbar wraps with `flex-wrap: wrap` + `gap: 8px`, spacer hidden, Add Todo button uses `white-space: nowrap` with compact sizing (specificity `0,3,0` to override theme rules), search input fills available space, secondary buttons and selects get reduced padding/font-size, username and areas label truncated more aggressively
- **768px breakpoint (sidebar)**: Add Project form becomes inline flex layout (input + button side by side), Manage Projects button uses auto-width
- **400px breakpoint**: Further reduces Add Todo button size, areas label max-width, username max-width, and search min-width for narrow phones

## Testing
- [x] CSS selector validation passes (0 broken selectors)
- [ ] Test at 768px, 400px, and 320px widths in browser DevTools
- [ ] Verify all toolbar items visible and accessible
- [ ] Test with Glass, Dark, and Clear themes
- [ ] Verify dropdown menus position correctly when toolbar wraps

Fixes #231

Generated with [Claude Code](https://claude.com/claude-code)