### PR TITLE
fix: Redesign manage projects dialog for mobile view (fixes #233)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2950,6 +2950,52 @@ body.sidebar-resizing * {
         padding: 4px 8px;
         font-size: 12px;
     }
+
+    /* === MOBILE MANAGE PROJECTS DIALOG === */
+    /* Line 1: color + project name/description + edit/delete */
+    /* Line 2: area dropdown (full width) */
+    .manage-projects-item {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        grid-template-rows: auto auto;
+        gap: 6px 10px;
+        padding: 12px;
+        align-items: center;
+    }
+
+    .manage-projects-drag-handle {
+        display: none;
+    }
+
+    .manage-projects-color {
+        grid-column: 1;
+        grid-row: 1;
+    }
+
+    .manage-projects-details {
+        grid-column: 2;
+        grid-row: 1;
+        min-width: 0;
+    }
+
+    .manage-projects-actions {
+        grid-column: 3;
+        grid-row: 1;
+        opacity: 1;
+    }
+
+    .manage-projects-area {
+        grid-column: 2 / -1;
+        grid-row: 2;
+        max-width: none;
+        width: 100%;
+    }
+
+    .manage-projects-edit,
+    .manage-projects-delete {
+        padding: 6px 10px;
+        font-size: 16px;
+    }
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
- Redesigns the manage projects modal dialog for mobile screens with a clean two-line grid layout

## Problem
On mobile devices, the manage projects dialog displays all elements (drag handle, color picker, project name, description, area dropdown, edit/delete buttons) in a single cramped row. The edit and delete buttons are also hidden behind hover state, which doesn't work on touch devices (see #233).

## Solution
Add responsive CSS in the 768px media query that switches the manage projects item layout from a single-row flex to a two-line CSS grid:
- **Line 1**: Color picker + project name/description + edit/delete buttons
- **Line 2**: Area dropdown spanning full width for better readability

## Changes
- `styles.css`: Add mobile manage projects styles in the `@media (max-width: 768px)` block:
  - CSS grid layout with `grid-template-columns: auto 1fr auto`
  - Hide drag handle (unreliable on touch devices)
  - Make edit/delete actions always visible (`opacity: 1`)
  - Remove area dropdown `max-width` constraint
  - Increase touch target size for edit/delete buttons

## Testing
- [x] CSS selector validator passes
- [x] Desktop layout unchanged (styles scoped to 768px media query)
- [x] Two-line grid layout for mobile with proper alignment

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)