### PR TITLE
fix: Redesign Add Todo dialog for mobile view (fixes #239)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2669,16 +2669,47 @@ body.sidebar-resizing * {
 }
 
 @media (max-width: 600px) {
+    /* Modal sidebar keeps 3-column grid on mobile */
+
     .modal-form-sidebar {
-        grid-template-columns: repeat(2, 1fr);
+        gap: 8px 8px;
+        padding: 10px;
+    }
+
+    .modal-sidebar-field label {
+        gap: 4px;
+    }
+
+    .modal-field-icon {
+        display: none;
+    }
+
+    .modal-field-label {
+        font-size: 11px;
+    }
+
+    .modal-sidebar-select,
+    .modal-sidebar-input {
+        padding: 5px 4px;
+        font-size: 12px;
+    }
+
+    .modal-tab {
+        padding: 8px 10px;
+        font-size: 13px;
+    }
+
+    .modal-tab-panel.active {
+        gap: 10px;
+    }
+
+    .modal {
+        padding: 20px;
+        width: 95%;
     }
 }
 
 @media (max-width: 400px) {
-    .modal-form-sidebar {
-        grid-template-columns: 1fr;
-    }
-
     .content-toolbar .toolbar-btn.add-todo-btn {
         padding: 6px 10px;
         font-size: 12px;


### PR DESCRIPTION
## Summary
- Redesign the Add Todo modal sidebar for mobile screens to keep a compact 3-column grid layout instead of collapsing to fewer columns

## Problem
On mobile screens (≤600px), the Add Todo dialog's sidebar metadata fields collapsed from 3 columns to 2 columns, and on very small screens (≤400px), to a single column. This wasted vertical space and didn't match the intended mobile design shown in #239.

## Solution
- Removed the grid column reduction at 600px and 400px breakpoints
- Instead, made the sidebar fields more compact at ≤600px to fit 3 columns:
  - Reduced gaps and padding in the sidebar grid
  - Hidden field icons to save horizontal space
  - Reduced font sizes for labels and select/input elements
  - Made modal slightly wider (95% vs 90%) with reduced padding
  - Compacted tab button sizes

## Changes
- `styles.css` - Updated `@media (max-width: 600px)` and `@media (max-width: 400px)` breakpoints for modal sidebar layout

## Testing
- [x] CSS selector validation passes
- [x] Code formatted per project conventions

Fixes #239

Generated with [Claude Code](https://claude.com/claude-code)