### PR TITLE
Make GTD status section collapsible in sidebar

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,6 +73,7 @@ class TodoApp {
         this.newProjectInput = document.getElementById('newProjectInput')
         this.addProjectBtn = document.getElementById('addProjectBtn')
         this.projectsSection = document.getElementById('projectsSection')
+        this.gtdSection = document.getElementById('gtdSection')
         this.gtdList = document.getElementById('gtdList')
         this.exportBtn = document.getElementById('exportBtn')
         this.searchInput = document.getElementById('searchInput')
@@ -357,6 +358,9 @@ class TodoApp {
         })
 
         // Collapsible sidebar sections
+        this.gtdSection.querySelector('.sidebar-section-header').addEventListener('click', () => {
+            this.toggleSidebarSection(this.gtdSection)
+        })
         this.projectsSection.querySelector('.sidebar-section-header').addEventListener('click', () => {
             this.toggleSidebarSection(this.projectsSection)
         })

--- a/index.html
+++ b/index.html
@@ -78,9 +78,15 @@
                         </div>
                     </div>
 
-                    <!-- GTD Section -->
-                    <div class="gtd-section">
-                        <ul id="gtdList" class="gtd-list"></ul>
+                    <!-- GTD Section (expanded by default) -->
+                    <div class="sidebar-section" id="gtdSection">
+                        <div class="sidebar-section-header" role="button" aria-expanded="true" aria-controls="gtdContent">
+                            <h2>Status</h2>
+                            <span class="sidebar-section-toggle" aria-hidden="true">▼</span>
+                        </div>
+                        <div class="sidebar-section-content" id="gtdContent">
+                            <ul id="gtdList" class="gtd-list"></ul>
+                        </div>
                     </div>
 
                     <!-- Projects Section (expanded by default) -->

--- a/styles.css
+++ b/styles.css
@@ -3033,10 +3033,6 @@ body.sidebar-resizing * {
    GTD Sidebar Section
    ======================================== */
 
-.gtd-section {
-    margin-bottom: 25px;
-}
-
 .gtd-list {
     list-style: none;
     padding-left: 1px; /* Prevents Safari from clipping left border of items with border-radius */
@@ -4773,13 +4769,6 @@ body.sidebar-resizing * {
 /* ========================================
    Glass Theme - GTD Elements
    ======================================== */
-
-/* iOS GTD Section */
-[data-theme="glass"] .gtd-section,
-[data-theme="dark"] .gtd-section,
-[data-theme="clear"] .gtd-section {
-    margin-bottom: 20px;
-}
 
 [data-theme="glass"] .gtd-list,
 [data-theme="dark"] .gtd-list,


### PR DESCRIPTION
## Summary
- Wraps the GTD status list (Inbox, Next, Scheduled, Waiting, Someday, Done) in a collapsible `sidebar-section` container
- Reuses the existing Projects section pattern: toggle arrow, ARIA attributes, smooth CSS animation
- Cleans up orphaned `.gtd-section` CSS rules

Fixes #241

## Test plan
- [ ] Verify GTD section has "STATUS" header with collapse toggle arrow
- [ ] Click header to collapse/expand the GTD list
- [ ] Verify ARIA attributes update (`aria-expanded` toggles true/false)
- [ ] Verify Projects section still collapses independently
- [ ] Test in glass/dark/clear themes
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)