### PR TITLE
feat: Display daily quote in empty Inbox zen state (fixes #242)

### DIFF
--- a/src/services/quotes.js
+++ b/src/services/quotes.js
@@ -1,0 +1,115 @@
+const CACHE_KEY = 'dailyQuote'
+
+const FALLBACK_QUOTES = [
+    { quote: 'The secret of getting ahead is getting started.', author: 'Mark Twain' },
+    { quote: 'It is not enough to be busy; so are the ants. The question is: What are we busy about?', author: 'Henry David Thoreau' },
+    { quote: 'The best time to plant a tree was 20 years ago. The second best time is now.', author: 'Chinese Proverb' },
+    { quote: 'Do what you can, with what you have, where you are.', author: 'Theodore Roosevelt' },
+    { quote: 'Simplicity is the ultimate sophistication.', author: 'Leonardo da Vinci' },
+    { quote: 'The only way to do great work is to love what you do.', author: 'Steve Jobs' },
+    { quote: 'Start where you are. Use what you have. Do what you can.', author: 'Arthur Ashe' },
+    { quote: 'He who has a why to live can bear almost any how.', author: 'Friedrich Nietzsche' },
+    { quote: 'In the middle of difficulty lies opportunity.', author: 'Albert Einstein' },
+    { quote: 'Well done is better than well said.', author: 'Benjamin Franklin' },
+    { quote: 'What we think, we become.', author: 'Buddha' },
+    { quote: 'An unexamined life is not worth living.', author: 'Socrates' },
+    { quote: 'Life is what happens when you are busy making other plans.', author: 'John Lennon' },
+    { quote: 'The mind is everything. What you think you become.', author: 'Buddha' },
+    { quote: 'Happiness is not something ready made. It comes from your own actions.', author: 'Dalai Lama' },
+    { quote: 'A journey of a thousand miles begins with a single step.', author: 'Lao Tzu' },
+    { quote: 'The best revenge is massive success.', author: 'Frank Sinatra' },
+    { quote: 'Everything you can imagine is real.', author: 'Pablo Picasso' },
+    { quote: 'If you want to lift yourself up, lift up someone else.', author: 'Booker T. Washington' },
+    { quote: 'The purpose of our lives is to be happy.', author: 'Dalai Lama' },
+    { quote: 'You must be the change you wish to see in the world.', author: 'Mahatma Gandhi' },
+    { quote: 'Peace comes from within. Do not seek it without.', author: 'Buddha' },
+    { quote: 'Knowing yourself is the beginning of all wisdom.', author: 'Aristotle' },
+    { quote: 'The only true wisdom is in knowing you know nothing.', author: 'Socrates' },
+    { quote: 'Turn your wounds into wisdom.', author: 'Oprah Winfrey' },
+    { quote: 'Yesterday is history, tomorrow is a mystery, today is a gift of God, which is why we call it the present.', author: 'Bill Keane' },
+    { quote: 'It does not matter how slowly you go as long as you do not stop.', author: 'Confucius' },
+    { quote: 'Nothing is impossible, the word itself says I\'m possible!', author: 'Audrey Hepburn' },
+    { quote: 'The best way to predict the future is to create it.', author: 'Peter Drucker' },
+    { quote: 'What lies behind us and what lies before us are tiny matters compared to what lies within us.', author: 'Ralph Waldo Emerson' },
+    { quote: 'Believe you can and you are halfway there.', author: 'Theodore Roosevelt' },
+]
+
+/**
+ * Get the day of the year (1-366)
+ * @returns {number}
+ */
+function getDayOfYear() {
+    const now = new Date()
+    const start = new Date(now.getFullYear(), 0, 0)
+    const diff = now - start
+    const oneDay = 1000 * 60 * 60 * 24
+    return Math.floor(diff / oneDay)
+}
+
+/**
+ * Get a cached quote from sessionStorage if it's still valid for today
+ * @returns {{ quote: string, author: string } | null}
+ */
+function getCachedQuote() {
+    try {
+        const cached = sessionStorage.getItem(CACHE_KEY)
+        if (!cached) return null
+        const parsed = JSON.parse(cached)
+        if (parsed.day === getDayOfYear() && parsed.quote && parsed.author) {
+            return { quote: parsed.quote, author: parsed.author }
+        }
+    } catch {
+        // Ignore parse errors
+    }
+    return null
+}
+
+/**
+ * Cache a quote in sessionStorage
+ * @param {{ quote: string, author: string }} quoteData
+ */
+function cacheQuote(quoteData) {
+    try {
+        sessionStorage.setItem(CACHE_KEY, JSON.stringify({
+            day: getDayOfYear(),
+            quote: quoteData.quote,
+            author: quoteData.author,
+        }))
+    } catch {
+        // Ignore storage errors
+    }
+}
+
+/**
+ * Get a fallback quote based on the day of the year
+ * @returns {{ quote: string, author: string }}
+ */
+function getFallbackQuote() {
+    const index = getDayOfYear() % FALLBACK_QUOTES.length
+    return FALLBACK_QUOTES[index]
+}
+
+/**
+ * Fetch the daily quote. Uses sessionStorage cache, then tries an external API,
+ * falling back to a built-in list of quotes.
+ * @returns {Promise<{ quote: string, author: string }>}
+ */
+export async function getDailyQuote() {
+    const cached = getCachedQuote()
+    if (cached) return cached
+
+    try {
+        // Use day-of-year to pick a consistent quote for the day (API has 1454 quotes)
+        const quoteId = (getDayOfYear() % 1454) + 1
+        const response = await fetch(`https://dummyjson.com/quotes/${quoteId}`)
+        if (!response.ok) throw new Error('API error')
+        const data = await response.json()
+        const quoteData = { quote: data.quote, author: data.author }
+        cacheQuote(quoteData)
+        return quoteData
+    } catch {
+        const fallback = getFallbackQuote()
+        cacheQuote(fallback)
+        return fallback
+    }
+}

--- a/src/ui/TodoList.js
+++ b/src/ui/TodoList.js
@@ -5,6 +5,7 @@ import { getFilteredTodos, toggleTodo, deleteTodo, updateTodoProject, updateTodo
 import { getCategoryById } from '../services/categories.js'
 import { getPriorityById } from '../services/priorities.js'
 import { getContextById } from '../services/contexts.js'
+import { getDailyQuote } from '../services/quotes.js'
 
 /**
  * Get human-readable label for a GTD status
@@ -127,9 +128,22 @@ export function renderTodos(container, options = {}) {
                     </svg>
                     <h3 class="zen-title">Inbox Zero</h3>
                     <p class="zen-message">Your mind is clear. All items have been processed. Take a moment to breathe.</p>
+                    <div class="zen-quote-container" id="zenQuoteContainer"></div>
                 </div>
             `
             container.appendChild(zenState)
+
+            // Load daily quote asynchronously
+            const quoteContainer = document.getElementById('zenQuoteContainer')
+            getDailyQuote().then(({ quote, author }) => {
+                quoteContainer.innerHTML = `
+                    <blockquote class="zen-quote">
+                        <p class="zen-quote-text">\u201C${escapeHtml(quote)}\u201D</p>
+                        <footer class="zen-quote-author">\u2014 ${escapeHtml(author)}</footer>
+                    </blockquote>
+                `
+                quoteContainer.classList.add('loaded')
+            })
         } else {
             let emptyMsg
             if (state.searchQuery) {

--- a/styles.css
+++ b/styles.css
@@ -1120,6 +1120,36 @@ body.sidebar-resizing * {
     line-height: 1.5;
 }
 
+.zen-quote-container {
+    max-width: 360px;
+    opacity: 0;
+    transition: opacity 0.5s ease-in;
+    margin-top: 8px;
+}
+
+.zen-quote-container.loaded {
+    opacity: 1;
+}
+
+.zen-quote {
+    margin: 0;
+    padding: 0;
+    border: none;
+}
+
+.zen-quote-text {
+    font-size: 14px;
+    font-style: italic;
+    color: #777;
+    line-height: 1.6;
+    margin: 0 0 8px 0;
+}
+
+.zen-quote-author {
+    font-size: 12px;
+    color: #aaa;
+}
+
 .loading-state {
     text-align: center;
     color: var(--accent-color);
@@ -4743,6 +4773,18 @@ body.sidebar-resizing * {
 [data-theme="dark"] .inbox-zen-state .zen-illustration,
 [data-theme="clear"] .inbox-zen-state .zen-illustration {
     opacity: 0.9;
+}
+
+[data-theme="glass"] .zen-quote-text,
+[data-theme="dark"] .zen-quote-text,
+[data-theme="clear"] .zen-quote-text {
+    color: var(--ios-label-secondary);
+}
+
+[data-theme="glass"] .zen-quote-author,
+[data-theme="dark"] .zen-quote-author,
+[data-theme="clear"] .zen-quote-author {
+    color: var(--ios-label-tertiary);
 }
 
 /* iOS Messages */


### PR DESCRIPTION
## Summary
- Adds a daily inspirational quote to the "Inbox Zero" zen state shown when the inbox is empty
- Quotes are fetched from an external API with caching and offline fallback

## Problem
When the Inbox is empty, the zen state only shows a static message. Issue #242 requested displaying an "idea for today" / "thought for today" / "quotation for today" when the Inbox is empty.

## Solution
Created a quote service (`src/services/quotes.js`) that:
- Fetches a daily quote from `dummyjson.com/quotes` (free, CORS-enabled, 1454+ quotes)
- Selects a quote deterministically based on the day of the year (same quote all day)
- Caches the result in `sessionStorage` to avoid repeated API calls
- Falls back to a built-in list of 31 curated quotes if the API is unreachable

The quote is displayed as a blockquote below the existing zen message with a smooth fade-in animation.

## Changes
- `src/services/quotes.js` — New service for fetching and caching daily quotes
- `src/ui/TodoList.js` — Renders the daily quote in the inbox zen state
- `styles.css` — Quote styling with theme support (glass, dark, clear)

## Testing
- [x] CSS selectors validated
- [x] User input sanitized with `escapeHtml()` for both quote text and author
- [x] Graceful fallback when API is unreachable
- [x] SessionStorage caching prevents unnecessary API calls
- [x] Theme support for glass/dark/clear themes

Fixes #242

Generated with [Claude Code](https://claude.com/claude-code)