### PR TITLE
feat: Modernize application icons with consistent SVG design

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,11 @@
                     <div class="sidebar-section" id="gtdSection">
                         <div class="sidebar-section-header" role="button" aria-expanded="true" aria-controls="gtdContent">
                             <h2>Status</h2>
-                            <span class="sidebar-section-toggle" aria-hidden="true">▼</span>
+                            <span class="sidebar-section-toggle" aria-hidden="true">
+                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <polyline points="6 9 12 15 18 9"/>
+                                </svg>
+                            </span>
                         </div>
                         <div class="sidebar-section-content" id="gtdContent">
                             <ul id="gtdList" class="gtd-list"></ul>
@@ -93,7 +97,11 @@
                     <div class="sidebar-section" id="projectsSection">
                         <div class="sidebar-section-header" role="button" aria-expanded="true" aria-controls="projectsContent">
                             <h2>Projects</h2>
-                            <span class="sidebar-section-toggle" aria-hidden="true">▼</span>
+                            <span class="sidebar-section-toggle" aria-hidden="true">
+                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <polyline points="6 9 12 15 18 9"/>
+                                </svg>
+                            </span>
                         </div>
                         <div class="sidebar-section-content" id="projectsContent">
                             <ul id="projectList" class="project-list"></ul>
@@ -123,27 +131,52 @@
                         <div class="toolbar-areas-menu" id="toolbarAreasMenu">
                             <button class="toolbar-areas-btn" id="toolbarAreasBtn" aria-haspopup="true" aria-expanded="false">
                                 <span class="toolbar-areas-label" id="toolbarAreasLabel">All Areas</span>
-                                <span class="toolbar-menu-arrow">▼</span>
+                                <span class="toolbar-menu-arrow">
+                                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                                        <polyline points="6 9 12 15 18 9"/>
+                                    </svg>
+                                </span>
                             </button>
                             <div class="toolbar-areas-dropdown" id="toolbarAreasDropdown" role="menu">
                                 <button class="toolbar-dropdown-item toolbar-areas-item" data-area-id="all" role="menuitem">
-                                    <span class="areas-item-icon">☰</span>
+                                    <span class="areas-item-icon">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                            <polygon points="12 2 2 7 12 12 22 7 12 2"/>
+                                            <polyline points="2 17 12 22 22 17"/>
+                                            <polyline points="2 12 12 17 22 12"/>
+                                        </svg>
+                                    </span>
                                     <span class="areas-item-label">All Areas</span>
                                     <span class="areas-item-shortcut">⇧0</span>
                                 </button>
                                 <button class="toolbar-dropdown-item toolbar-areas-item" data-area-id="unassigned" role="menuitem">
-                                    <span class="areas-item-icon">📁</span>
+                                    <span class="areas-item-icon">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                            <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
+                                            <polyline points="13 2 13 9 20 9"/>
+                                        </svg>
+                                    </span>
                                     <span class="areas-item-label">Unassigned</span>
                                 </button>
                                 <div class="toolbar-dropdown-divider"></div>
                                 <div id="areaListContainer"></div>
                                 <div class="toolbar-dropdown-divider" id="areaListDivider"></div>
                                 <button class="toolbar-dropdown-item toolbar-areas-action" id="addAreaBtn" role="menuitem">
-                                    <span class="areas-item-icon">+</span>
+                                    <span class="areas-item-icon">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                            <line x1="12" y1="5" x2="12" y2="19"/>
+                                            <line x1="5" y1="12" x2="19" y2="12"/>
+                                        </svg>
+                                    </span>
                                     <span class="areas-item-label">Add New Area</span>
                                 </button>
                                 <button class="toolbar-dropdown-item toolbar-areas-action" id="manageAreasBtn" role="menuitem">
-                                    <span class="areas-item-icon">⚙</span>
+                                    <span class="areas-item-icon">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                            <circle cx="12" cy="12" r="3"/>
+                                            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+                                        </svg>
+                                    </span>
                                     <span class="areas-item-label">Manage Areas</span>
                                 </button>
                             </div>
@@ -173,7 +206,11 @@
                         <div class="toolbar-user-menu" id="toolbarUserMenu">
                             <button class="toolbar-user-btn" id="toolbarUserBtn" aria-haspopup="true" aria-expanded="false">
                                 <span class="toolbar-username" id="toolbarUsername"></span>
-                                <span class="toolbar-menu-arrow">▼</span>
+                                <span class="toolbar-menu-arrow">
+                                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                                        <polyline points="6 9 12 15 18 9"/>
+                                    </svg>
+                                </span>
                             </button>
                             <div class="toolbar-dropdown" id="toolbarDropdown" role="menu">
                                 <button id="settingsBtn" class="toolbar-dropdown-item" role="menuitem">Settings</button>

--- a/src/ui/AreasDropdown.js
+++ b/src/ui/AreasDropdown.js
@@ -2,6 +2,7 @@ import { store } from '../core/store.js'
 import { escapeHtml, validateColor } from '../utils/security.js'
 import { selectArea, reorderAreas, renameArea, deleteArea, updateArea, loadAreas } from '../services/areas.js'
 import { loadProjects } from '../services/projects.js'
+import { getIcon } from '../utils/icons.js'
 
 /**
  * Render the areas dropdown menu
@@ -29,7 +30,7 @@ export function renderAreasDropdown(listContainer, dropdown, divider) {
         // Show color dot if area has a color
         const colorDot = area.color
             ? `<span class="area-color-dot" style="background-color: ${validateColor(area.color)}"></span>`
-            : `<span class="areas-item-icon">\ud83d\udcc2</span>`
+            : `<span class="areas-item-icon">${getIcon('folder', { size: 16 })}</span>`
         button.innerHTML = `
             ${colorDot}
             <span class="areas-item-label">${escapeHtml(area.name)}</span>
@@ -116,12 +117,12 @@ export function renderManageAreasList(container) {
         li.draggable = true
         const areaColor = area.color || '#667eea'
         li.innerHTML = `
-            <span class="manage-areas-drag-handle">\u22ee\u22ee</span>
+            <span class="manage-areas-drag-handle">${getIcon('drag-handle', { size: 16 })}</span>
             <input type="color" class="manage-areas-color" value="${validateColor(areaColor)}" title="Change color">
             <span class="manage-areas-name">${escapeHtml(area.name)}</span>
             <div class="manage-areas-actions">
-                <button class="manage-areas-edit" data-id="${area.id}" title="Rename">\u270e</button>
-                <button class="manage-areas-delete" data-id="${area.id}" title="Delete">\u00d7</button>
+                <button class="manage-areas-edit" data-id="${area.id}" title="Rename">${getIcon('edit', { size: 14 })}</button>
+                <button class="manage-areas-delete" data-id="${area.id}" title="Delete">${getIcon('x', { size: 14 })}</button>
             </div>
         `
 

--- a/src/ui/GtdList.js
+++ b/src/ui/GtdList.js
@@ -1,23 +1,15 @@
 import { store } from '../core/store.js'
 import { escapeHtml } from '../utils/security.js'
 import { getGtdCount, updateTodoGtdStatus } from '../services/todos.js'
+import { getIcon } from '../utils/icons.js'
 
 /**
  * Get icon for a GTD status
  * @param {string} status - GTD status
- * @returns {string} Emoji icon
+ * @returns {string} SVG icon markup
  */
 export function getGtdIcon(status) {
-    const icons = {
-        'inbox': '\ud83d\udce5',
-        'next_action': '\u00bb',
-        'scheduled': '\ud83d\udcc6',
-        'waiting_for': '\u23f3',
-        'someday_maybe': '\ud83d\udcc5',
-        'done': '\u2713',
-        'all': '\u2630'
-    }
-    return icons[status] || '\u2022'
+    return getIcon(status, { size: 18 })
 }
 
 /**

--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -2,6 +2,7 @@ import { store } from '../core/store.js'
 import { escapeHtml, validateColor } from '../utils/security.js'
 import { getFilteredProjects, selectProject, deleteProject, updateProject, reorderProjects } from '../services/projects.js'
 import { getProjectTodoCount, updateTodoProject } from '../services/todos.js'
+import { getIcon } from '../utils/icons.js'
 
 /**
  * Render the project list in the sidebar
@@ -55,7 +56,7 @@ export function renderProjects(container) {
                 ${escapeHtml(project.name)}
             </span>
             <span class="project-count">${countDisplay}</span>
-            <button class="project-delete" data-id="${project.id}">\u00d7</button>
+            <button class="project-delete" data-id="${project.id}">${getIcon('x', { size: 12 })}</button>
         `
 
         li.addEventListener('click', (e) => {
@@ -137,7 +138,7 @@ export function renderManageProjectsList(container) {
         })
 
         li.innerHTML = `
-            <span class="manage-projects-drag-handle">\u22ee\u22ee</span>
+            <span class="manage-projects-drag-handle">${getIcon('drag-handle', { size: 16 })}</span>
             <input type="color" class="manage-projects-color" value="${validateColor(projectColor)}" title="Change color">
             <div class="manage-projects-details">
                 <span class="manage-projects-name">${escapeHtml(project.name)}</span>
@@ -145,8 +146,8 @@ export function renderManageProjectsList(container) {
             </div>
             <select class="manage-projects-area" title="Assign to area">${areaOptions}</select>
             <div class="manage-projects-actions">
-                <button class="manage-projects-edit" data-id="${project.id}" title="Edit">\u270e</button>
-                <button class="manage-projects-delete" data-id="${project.id}" title="Delete">\u00d7</button>
+                <button class="manage-projects-edit" data-id="${project.id}" title="Edit">${getIcon('edit', { size: 14 })}</button>
+                <button class="manage-projects-delete" data-id="${project.id}" title="Delete">${getIcon('x', { size: 14 })}</button>
             </div>
         `
 

--- a/src/ui/TodoList.js
+++ b/src/ui/TodoList.js
@@ -6,6 +6,7 @@ import { getCategoryById } from '../services/categories.js'
 import { getPriorityById } from '../services/priorities.js'
 import { getContextById } from '../services/contexts.js'
 import { getDailyQuote } from '../services/quotes.js'
+import { getIcon } from '../utils/icons.js'
 
 /**
  * Get human-readable label for a GTD status
@@ -210,14 +211,7 @@ export function renderTodos(container, options = {}) {
 
         // Recurring icon for todos linked to a template
         const recurringIcon = todo.template_id
-            ? `<span class="recurring-icon" title="Recurring">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <polyline points="17 1 21 5 17 9"/>
-                    <path d="M3 11V9a4 4 0 0 1 4-4h14"/>
-                    <polyline points="7 23 3 19 7 15"/>
-                    <path d="M21 13v2a4 4 0 0 1-4 4H3"/>
-                </svg>
-               </span>`
+            ? `<span class="recurring-icon" title="Recurring">${getIcon('repeat', { size: 14 })}</span>`
             : ''
 
         if (category) {
@@ -232,7 +226,7 @@ export function renderTodos(container, options = {}) {
                 data-id="${todo.id}"
                 aria-label="Select todo"
             >
-            <span class="drag-handle" draggable="true">\u22ee\u22ee</span>
+            <span class="drag-handle" draggable="true">${getIcon('drag-handle', { size: 14 })}</span>
             <input
                 type="checkbox"
                 class="todo-checkbox"

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -1,0 +1,201 @@
+/**
+ * Modern SVG icons for the application
+ * Using outline-style icons inspired by Feather Icons / Lucide
+ */
+
+/**
+ * Get SVG icon markup for a given icon name
+ * @param {string} name - Icon name
+ * @param {Object} options - Icon options
+ * @param {number} options.size - Icon size (default: 16)
+ * @param {string} options.className - Additional CSS class
+ * @returns {string} SVG markup
+ */
+export function getIcon(name, options = {}) {
+    const { size = 16, className = '' } = options
+    const icons = {
+        // GTD Status Icons
+        'inbox': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/>
+            <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/>
+        </svg>`,
+
+        'next_action': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"/>
+            <polyline points="12 8 16 12 12 16"/>
+            <line x1="8" y1="12" x2="16" y2="12"/>
+        </svg>`,
+
+        'scheduled': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+            <line x1="16" y1="2" x2="16" y2="6"/>
+            <line x1="8" y1="2" x2="8" y2="6"/>
+            <line x1="3" y1="10" x2="21" y2="10"/>
+        </svg>`,
+
+        'waiting_for': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"/>
+            <polyline points="12 6 12 12 16 14"/>
+        </svg>`,
+
+        'someday_maybe': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9z"/>
+        </svg>`,
+
+        'done': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"/>
+            <polyline points="9 12 12 15 16 10"/>
+        </svg>`,
+
+        'all': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="8" y1="6" x2="21" y2="6"/>
+            <line x1="8" y1="12" x2="21" y2="12"/>
+            <line x1="8" y1="18" x2="21" y2="18"/>
+            <line x1="3" y1="6" x2="3.01" y2="6"/>
+            <line x1="3" y1="12" x2="3.01" y2="12"/>
+            <line x1="3" y1="18" x2="3.01" y2="18"/>
+        </svg>`,
+
+        // Area/Folder Icons
+        'folder': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+        </svg>`,
+
+        'folder-open': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M5 19a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h4l2 2h7a2 2 0 0 1 2 2v1"/>
+            <path d="M5 19l2.9-7.2a2 2 0 0 1 1.9-1.3h10.4a2 2 0 0 1 1.9 2.6l-2.4 6a2 2 0 0 1-1.9 1.4H5z"/>
+        </svg>`,
+
+        // Action Icons
+        'plus': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19"/>
+            <line x1="5" y1="12" x2="19" y2="12"/>
+        </svg>`,
+
+        'settings': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="3"/>
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+        </svg>`,
+
+        'menu': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="3" y1="12" x2="21" y2="12"/>
+            <line x1="3" y1="6" x2="21" y2="6"/>
+            <line x1="3" y1="18" x2="21" y2="18"/>
+        </svg>`,
+
+        'edit': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+        </svg>`,
+
+        'trash': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3 6 5 6 21 6"/>
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+        </svg>`,
+
+        'x': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"/>
+            <line x1="6" y1="6" x2="18" y2="18"/>
+        </svg>`,
+
+        'chevron-down': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="6 9 12 15 18 9"/>
+        </svg>`,
+
+        'drag-handle': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="9" cy="5" r="1"/>
+            <circle cx="9" cy="12" r="1"/>
+            <circle cx="9" cy="19" r="1"/>
+            <circle cx="15" cy="5" r="1"/>
+            <circle cx="15" cy="12" r="1"/>
+            <circle cx="15" cy="19" r="1"/>
+        </svg>`,
+
+        'repeat': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="17 1 21 5 17 9"/>
+            <path d="M3 11V9a4 4 0 0 1 4-4h14"/>
+            <polyline points="7 23 3 19 7 15"/>
+            <path d="M21 13v2a4 4 0 0 1-4 4H3"/>
+        </svg>`,
+
+        'archive': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="21 8 21 21 3 21 3 8"/>
+            <rect x="1" y="3" width="22" height="5"/>
+            <line x1="10" y1="12" x2="14" y2="12"/>
+        </svg>`,
+
+        // Priority Icon
+        'star': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+        </svg>`,
+
+        'flag': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/>
+            <line x1="4" y1="22" x2="4" y2="15"/>
+        </svg>`,
+
+        // Tag Icon
+        'tag': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/>
+            <line x1="7" y1="7" x2="7.01" y2="7"/>
+        </svg>`,
+
+        // Location Icon
+        'map-pin': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+            <circle cx="12" cy="10" r="3"/>
+        </svg>`,
+
+        // Activity/Status Icon
+        'activity': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+        </svg>`,
+
+        // Search Icon
+        'search': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"/>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+        </svg>`,
+
+        // Check Icon
+        'check': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="20 6 9 17 4 12"/>
+        </svg>`,
+
+        // Circle Check Icon
+        'circle-check': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+            <polyline points="22 4 12 14.01 9 11.01"/>
+        </svg>`,
+
+        // Project Icon
+        'briefcase': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="7" width="20" height="14" rx="2" ry="2"/>
+            <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/>
+        </svg>`,
+
+        // Layers Icon (for Areas/All)
+        'layers': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="12 2 2 7 12 12 22 7 12 2"/>
+            <polyline points="2 17 12 22 22 17"/>
+            <polyline points="2 12 12 17 22 12"/>
+        </svg>`,
+
+        // File Icon (for unassigned)
+        'file': `<svg class="icon ${className}" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
+            <polyline points="13 2 13 9 20 9"/>
+        </svg>`
+    }
+
+    return icons[name] || icons['all']
+}
+
+/**
+ * Get GTD status icon as SVG
+ * @param {string} status - GTD status
+ * @returns {string} SVG markup
+ */
+export function getGtdIconSvg(status) {
+    return getIcon(status, { size: 16 })
+}

--- a/styles.css
+++ b/styles.css
@@ -541,7 +541,11 @@ body.sidebar-resizing * {
     justify-content: center;
     transition: transform 0.2s ease;
     color: #666;
-    font-size: 12px;
+}
+
+.sidebar-section-toggle svg {
+    width: 12px;
+    height: 12px;
 }
 
 .sidebar-section.collapsed .sidebar-section-toggle {
@@ -610,8 +614,15 @@ body.sidebar-resizing * {
     color: inherit;
     cursor: pointer;
     padding: 2px 5px;
-    font-size: 16px;
     transition: opacity 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.project-delete svg {
+    width: 12px;
+    height: 12px;
 }
 
 .project-item:hover .project-delete {
@@ -955,13 +966,20 @@ body.sidebar-resizing * {
 .drag-handle {
     cursor: grab;
     color: #888;
-    font-size: 18px;
     padding: 2px 6px;
     user-select: none;
     opacity: 0.6;
     transition: opacity 0.2s, color 0.2s, transform 0.2s, background-color 0.2s;
     border-radius: 4px;
     flex-shrink: 0; /* Prevent Safari iOS from shrinking */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.drag-handle svg {
+    width: 14px;
+    height: 14px;
 }
 
 .drag-handle:hover {
@@ -1314,9 +1332,16 @@ body.sidebar-resizing * {
 }
 
 .toolbar-menu-arrow {
-    font-size: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     color: #666;
     transition: transform 0.15s ease;
+}
+
+.toolbar-menu-arrow svg {
+    width: 10px;
+    height: 10px;
 }
 
 .toolbar-user-menu.open .toolbar-menu-arrow {
@@ -1450,8 +1475,16 @@ body.sidebar-resizing * {
 
 .areas-item-icon {
     width: 20px;
-    text-align: center;
-    font-size: 14px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.areas-item-icon svg {
+    width: 16px;
+    height: 16px;
 }
 
 .area-color-dot {
@@ -1579,7 +1612,14 @@ body.sidebar-resizing * {
     color: var(--ios-label-tertiary, #999);
     margin-right: 8px;
     cursor: grab;
-    font-size: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.manage-areas-drag-handle svg {
+    width: 16px;
+    height: 16px;
 }
 
 .manage-areas-color {
@@ -1639,9 +1679,17 @@ body.sidebar-resizing * {
     border: none;
     cursor: pointer;
     padding: 4px 8px;
-    font-size: 14px;
     border-radius: 4px;
     transition: background-color 0.15s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.manage-areas-edit svg,
+.manage-areas-delete svg {
+    width: 14px;
+    height: 14px;
 }
 
 .manage-areas-edit {
@@ -1749,8 +1797,15 @@ body.sidebar-resizing * {
 .manage-projects-drag-handle {
     color: var(--ios-label-tertiary, #999);
     cursor: grab;
-    font-size: 16px;
     flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.manage-projects-drag-handle svg {
+    width: 16px;
+    height: 16px;
 }
 
 .manage-projects-color,
@@ -1856,9 +1911,17 @@ body.sidebar-resizing * {
     border: none;
     cursor: pointer;
     padding: 4px 8px;
-    font-size: 14px;
     border-radius: 4px;
     transition: background 0.15s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.manage-projects-edit svg,
+.manage-projects-delete svg {
+    width: 14px;
+    height: 14px;
 }
 
 .manage-projects-edit {
@@ -3092,11 +3155,19 @@ body.sidebar-resizing * {
 }
 
 .gtd-icon {
-    width: 20px;
+    width: 22px;
+    height: 18px;
     margin-right: 10px;
-    text-align: center;
-    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     opacity: 0.7;
+    flex-shrink: 0;
+}
+
+.gtd-icon svg {
+    width: 18px;
+    height: 18px;
 }
 
 .gtd-item.active .gtd-icon {
@@ -4983,8 +5054,12 @@ body.sidebar-resizing * {
 }
 
 [data-density="compact"] .drag-handle {
-    font-size: 14px;
     padding: 1px 4px;
+}
+
+[data-density="compact"] .drag-handle svg {
+    width: 12px;
+    height: 12px;
 }
 
 [data-density="compact"] .todo-category-badge,


### PR DESCRIPTION
## Summary
- Replace emoji and text icons with modern outline-style SVG icons throughout the application
- Add new centralized icon utility (`src/utils/icons.js`) for consistent icon rendering
- Update GTD status, areas dropdown, sidebar toggles, drag handles, and action buttons to use SVG icons

## Changes
- **GTD Status Icons**: Modern outline icons for Inbox (tray), Next (arrow-circle), Scheduled (calendar), Waiting (clock), Someday (moon), Done (check-circle), All (list)
- **Areas Dropdown**: Layers icon for All Areas, file icon for Unassigned, plus icon for Add, settings icon for Manage
- **Sidebar Toggles**: Chevron icons replacing text arrows
- **Drag Handles**: 6-dot grip pattern replacing text characters
- **Action Buttons**: Edit (pencil) and delete (X) icons in manage modals
- **Recurring Indicator**: Repeat arrows icon for recurring tasks

## Test plan
- [ ] Verify GTD status icons display correctly in sidebar
- [ ] Verify areas dropdown icons display correctly
- [ ] Test sidebar section collapse/expand with new chevron icons
- [ ] Verify drag handles work correctly for todos, areas, and projects
- [ ] Test edit/delete buttons in manage areas and projects modals
- [ ] Verify recurring task icon displays correctly
- [ ] Test across different themes (Glass, Dark, Clear)
- [ ] Test in compact density mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)