### PR TITLE
fix: Move Save button to bottom of todo modal (fixes #252)

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,10 +301,6 @@
                                 rows="6"
                             ></textarea>
                         </div>
-                        <div class="modal-actions">
-                            <button type="submit" id="modalAddBtn" class="modal-btn modal-btn-primary">Save Changes</button>
-                            <button type="button" id="cancelModal" class="modal-btn modal-btn-secondary">Cancel</button>
-                        </div>
                     </div>
                     <div class="modal-form-sidebar">
                         <!-- Tab buttons -->
@@ -515,6 +511,10 @@
                             </div>
                         </div>
                         </div>
+                    </div>
+                    <div class="modal-actions">
+                        <button type="submit" id="modalAddBtn" class="modal-btn modal-btn-primary">Save Changes</button>
+                        <button type="button" id="cancelModal" class="modal-btn modal-btn-secondary">Cancel</button>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- Moves the Save/Cancel buttons to the bottom of the todo modal dialog

## Problem
The Save button was positioned in the middle of the todo modal (after the title and notes fields, but before the sidebar with Details/Repeat tabs). Users expect action buttons at the bottom of a form, after all input fields.

## Solution
Moved the `.modal-actions` div (containing Save and Cancel buttons) from inside `.modal-form-main` to after `.modal-form-sidebar`, making it the last child of the `<form>`. The existing CSS (`margin-top: auto` on `.modal-form-split .modal-actions`) correctly pushes the buttons to the bottom of the flex column layout.

## Changes
- `index.html` — Relocated the `.modal-actions` div from inside `.modal-form-main` to the end of the form, after `.modal-form-sidebar`

## Testing
- [x] CSS selector validation passes (`npm run check:css`)
- [x] No JavaScript changes needed — button IDs and form structure unchanged

Fixes #252

Generated with [Claude Code](https://claude.com/claude-code)