### PR TITLE
fix: Keep GTD tab bar visible when sidebar has many items (fixes #274)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -409,6 +409,7 @@ body.fullscreen-mode .app-container.active {
 body.fullscreen-mode .main-content {
     flex: 1;
     min-height: 0;
+    overflow: hidden;
 }
 
 body.fullscreen-mode .content {


### PR DESCRIPTION
## Summary
- Fixed the GTD tab bar being pushed off-screen when the sidebar has many projects

## Problem
When the projects list in the sidebar is long enough, the entire sidebar grows beyond the viewport height, pushing the sticky GTD status tab bar off-screen and making it invisible (see #274).

## Solution
Added `overflow: hidden` to `.main-content` in fullscreen mode. This constrains the flex row to its allocated height from the flex column parent, which in turn forces the sidebar to respect its `overflow: hidden` and lets the `.sidebar-scroll-area` scroll its content while the tab bar stays pinned at the bottom.

## Changes
- `styles.css`: Added `overflow: hidden` to `body.fullscreen-mode .main-content`

## Testing
- [x] CSS selector validation passes
- [ ] Open app with many projects and verify tab bar stays visible at sidebar bottom
- [ ] Verify projects list scrolls independently within the sidebar
- [ ] Test across themes (glass, dark, clear)

Fixes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)