### PR TITLE
Add GTD status header to content area (fixes #276)

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ import { loadPriorities } from './src/services/priorities.js'
 // UI Components
 import { renderTodos } from './src/ui/TodoList.js'
 import { renderProjects, updateProjectSelect, renderManageProjectsList } from './src/ui/ProjectList.js'
-import { renderGtdTabBar, selectGtdStatus, selectGtdStatusByShortcut } from './src/ui/GtdList.js'
+import { renderGtdTabBar, updateGtdStatusHeader, selectGtdStatus, selectGtdStatusByShortcut } from './src/ui/GtdList.js'
 import { renderAreasDropdown, updateAreasLabel, updateAreaHeader, renderManageAreasList } from './src/ui/AreasDropdown.js'
 import { TodoModal } from './src/ui/modals/TodoModal.js'
 import { ImportModal } from './src/ui/modals/ImportModal.js'
@@ -77,6 +77,7 @@ class TodoApp {
         this.addProjectBtn = document.getElementById('addProjectBtn')
         this.projectsSection = document.getElementById('projectsSection')
         this.gtdTabBar = document.getElementById('gtdTabBar')
+        this.gtdStatusHeader = document.getElementById('gtdStatusHeader')
         this.exportBtn = document.getElementById('exportBtn')
         this.searchInput = document.getElementById('searchInput')
         this.versionNumberEl = document.getElementById('versionNumber')
@@ -1122,6 +1123,7 @@ class TodoApp {
 
     render() {
         renderGtdTabBar(this.gtdTabBar)
+        updateGtdStatusHeader(this.gtdStatusHeader)
         renderProjects(this.projectList)
         updateAreaHeader(this.areaHeader)
         renderTodos(this.todoList, {
@@ -1132,6 +1134,7 @@ class TodoApp {
 
     renderAll() {
         renderGtdTabBar(this.gtdTabBar)
+        updateGtdStatusHeader(this.gtdStatusHeader)
         renderProjects(this.projectList)
         renderAreasDropdown(this.areaListContainer, this.toolbarAreasDropdown, this.areaListDivider)
         updateAreasLabel(this.toolbarAreasLabel)

--- a/index.html
+++ b/index.html
@@ -219,6 +219,12 @@
                         </div>
                     </div>
 
+                    <!-- GTD Status Header -->
+                    <div id="gtdStatusHeader" class="gtd-status-header">
+                        <span class="gtd-status-header-icon"></span>
+                        <span class="gtd-status-header-name"></span>
+                    </div>
+
                     <div id="areaHeader" class="area-header" style="display: none;">
                         <span class="area-header-color"></span>
                         <span class="area-header-name"></span>

--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -149,6 +149,8 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.gtd-tab/,
     /\.gtd-tab-icon/,
     /\.gtd-tab-badge/,
+    // GTD status header (updated by JavaScript)
+    /\.gtd-status-header/,
     // Scheduled view headers (rendered by JavaScript)
     /\.scheduled-section-header/,
     /\.section-header-text/,

--- a/src/ui/GtdList.js
+++ b/src/ui/GtdList.js
@@ -2,6 +2,16 @@ import { store } from '../core/store.js'
 import { getGtdCount, updateTodoGtdStatus } from '../services/todos.js'
 import { getIcon } from '../utils/icons.js'
 
+const GTD_STATUSES = [
+    { id: 'inbox', label: 'Inbox' },
+    { id: 'next_action', label: 'Next' },
+    { id: 'scheduled', label: 'Scheduled', isVirtual: true },
+    { id: 'waiting_for', label: 'Waiting' },
+    { id: 'someday_maybe', label: 'Someday' },
+    { id: 'done', label: 'Done' },
+    { id: 'all', label: 'All' }
+]
+
 /**
  * Get keyboard shortcut for a GTD status
  * @param {string} status - GTD status
@@ -58,19 +68,9 @@ export function selectGtdStatusByShortcut(digit) {
 export function renderGtdTabBar(container) {
     const state = store.state
 
-    const statuses = [
-        { id: 'inbox', label: 'Inbox' },
-        { id: 'next_action', label: 'Next' },
-        { id: 'scheduled', label: 'Scheduled', isVirtual: true },
-        { id: 'waiting_for', label: 'Waiting' },
-        { id: 'someday_maybe', label: 'Someday' },
-        { id: 'done', label: 'Done' },
-        { id: 'all', label: 'All' }
-    ]
-
     container.innerHTML = ''
 
-    statuses.forEach(status => {
+    GTD_STATUSES.forEach(status => {
         const btn = document.createElement('button')
         const isActive = state.selectedGtdStatus === status.id
         const count = getGtdCount(status.id)
@@ -145,4 +145,21 @@ export function renderGtdTabBar(container) {
             tabs[nextIndex].focus()
         })
     }
+}
+
+/**
+ * Update the GTD status header in the content area
+ * @param {HTMLElement} headerElement - The #gtdStatusHeader element
+ */
+export function updateGtdStatusHeader(headerElement) {
+    const status = store.state.selectedGtdStatus
+    const statusInfo = GTD_STATUSES.find(s => s.id === status)
+    if (!statusInfo) return
+
+    const iconSpan = headerElement.querySelector('.gtd-status-header-icon')
+    const nameSpan = headerElement.querySelector('.gtd-status-header-name')
+
+    iconSpan.innerHTML = getIcon(status, { size: 20 })
+    nameSpan.textContent = statusInfo.label
+    headerElement.className = `gtd-status-header ${status}`
 }

--- a/styles.css
+++ b/styles.css
@@ -747,6 +747,38 @@ body.sidebar-resizing * {
 }
 
 /* Area Header - Shows current area with color indicator */
+/* GTD Status Header */
+.gtd-status-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    margin-bottom: 8px;
+    background: var(--ios-bg-secondary, rgba(0, 0, 0, 0.03));
+    border-radius: 10px;
+}
+
+.gtd-status-header-icon {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.gtd-status-header-name {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--ios-label, #333);
+}
+
+/* Per-status icon colors */
+.gtd-status-header.inbox .gtd-status-header-icon { color: #1976d2; }
+.gtd-status-header.next_action .gtd-status-header-icon { color: #388e3c; }
+.gtd-status-header.scheduled .gtd-status-header-icon { color: #e91e63; }
+.gtd-status-header.waiting_for .gtd-status-header-icon { color: #f57c00; }
+.gtd-status-header.someday_maybe .gtd-status-header-icon { color: #7b1fa2; }
+.gtd-status-header.done .gtd-status-header-icon { color: #2e7d32; }
+.gtd-status-header.all .gtd-status-header-icon { color: #607d8b; }
+
 .area-header {
     display: flex;
     align-items: center;
@@ -4424,6 +4456,18 @@ body.sidebar-resizing * {
 }
 
 /* Area Header Theme Styles */
+[data-theme="glass"] .gtd-status-header,
+[data-theme="dark"] .gtd-status-header,
+[data-theme="clear"] .gtd-status-header {
+    background: var(--ios-bg-secondary);
+}
+
+[data-theme="glass"] .gtd-status-header-name,
+[data-theme="dark"] .gtd-status-header-name,
+[data-theme="clear"] .gtd-status-header-name {
+    color: var(--ios-label);
+}
+
 [data-theme="glass"] .area-header,
 [data-theme="dark"] .area-header,
 [data-theme="clear"] .area-header {


### PR DESCRIPTION
## Summary
- Adds a header bar in the content area showing the current GTD status icon and name
- Provides clear visual indication of which GTD view is active (Inbox, Next, Scheduled, etc.)

## Problem
After moving GTD statuses from a labeled sidebar list to icon-only bottom tabs (#272), users lost the textual indication of which view they're currently in.

## Solution
Added a `gtd-status-header` element between the toolbar and the todo list that displays the current GTD status icon and label. The icon color matches the corresponding tab color for visual consistency.

## Changes
- `index.html` — Added `#gtdStatusHeader` div with icon and name spans
- `src/ui/GtdList.js` — Extracted `GTD_STATUSES` constant, added `updateGtdStatusHeader()` function
- `app.js` — Imported and wired `updateGtdStatusHeader` into `render()` and `renderAll()`
- `styles.css` — Added `.gtd-status-header` styles with per-status icon colors and theme variants
- `scripts/check-css-selectors.js` — Added dynamic selector pattern for new header

## Testing
- [x] CSS selector validation passes (`npm run check:css`)
- [x] Pre-commit hook passes
- [ ] Visual verification in browser

Fixes #276

Generated with [Claude Code](https://claude.com/claude-code)