### PR TITLE
fix: Pin container to viewport height to keep GTD tab bar visible (fixes #274)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -267,9 +267,10 @@ body.fullscreen-mode .container {
     max-width: none;
     border-radius: 0;
     box-shadow: none;
-    min-height: 100vh;
+    height: 100vh;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 }
 
 .container {


### PR DESCRIPTION
## Summary
- Fixes the GTD tab bar being pushed off-screen when there are many items (e.g. in Done view)

## Problem
PR #277 added `overflow: hidden` to `.main-content`, but that was insufficient. The root cause is that `.container` in fullscreen mode used `min-height: 100vh`, which allows it to **grow beyond** the viewport when content exceeds available space. This cascades through the flex chain:

`.container` grows → `.app-container` grows → `.main-content` grows → sidebar stretches to match → tab bar pushed off-screen

## Solution
Changed `.container` in fullscreen mode from `min-height: 100vh` to `height: 100vh` with `overflow: hidden`. This creates a hard viewport boundary that properly constrains the entire flex layout chain:

- `.container` = exactly 100vh (pinned)
- `.app-container` = remaining space (`flex: 1; min-height: 0`)
- `.main-content` = remaining space (`flex: 1; min-height: 0; overflow: hidden`)
- `.sidebar` = stretches to row height, scroll area scrolls, tab bar stays pinned
- `.content` = stretches to row height, todo list scrolls within

## Changes
- `styles.css`: Changed `min-height: 100vh` → `height: 100vh` and added `overflow: hidden` on `body.fullscreen-mode .container`

## Testing
- [x] CSS selector validation passes
- [ ] Open Done view with many completed items — tab bar stays visible at bottom
- [ ] Verify todo list scrolls within content area
- [ ] Verify sidebar projects scroll within sidebar scroll area
- [ ] Test across themes (glass, dark, clear)

Fixes #274

Generated with [Claude Code](https://claude.com/claude-code)