### PR TITLE
ci: Fix deploy workflow to deploy version bump commits

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,6 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Auto Version Bump"]
     types: [completed]
@@ -15,13 +16,17 @@ concurrency:
 jobs:
   deploy:
     # Deploy when:
-    # - Version bump succeeded, OR
+    # - Manual trigger (workflow_dispatch), OR
+    # - Version bump workflow succeeded, OR
+    # - Version bump PR merged to main, OR
     # - Direct push to main (not a PR merge that triggers version bump)
     if: |
+      (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'push' &&
-       !contains(github.event.head_commit.message, 'Merge pull request') &&
-       !contains(github.event.head_commit.message, '(#'))
+       (startsWith(github.event.head_commit.message, 'chore: Bump version') ||
+        (!contains(github.event.head_commit.message, 'Merge pull request') &&
+         !contains(github.event.head_commit.message, '(#'))))
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
## Summary
- Fixes version bump commits never being deployed to GitHub Pages
- Adds manual trigger support (`workflow_dispatch`)

## Problem
The deploy workflow skipped all PR merges (commits containing `(#`), expecting the Auto Version Bump `workflow_run` to trigger deployment. But when the version bump PR was merged:

1. Push event → skipped (commit contains `(#`)
2. Auto Version Bump → skipped (it's a version bump commit, not real code)
3. `workflow_run` event → skipped (conclusion was `skipped`, not `success`)

Result: version bumps were **never deployed**, so the version number displayed on the site was always one release behind.

## Solution
- Allow commits starting with `chore: Bump version` through the push deploy condition
- Added `workflow_dispatch` trigger for manual deployments as a safety valve

## Testing
- [ ] Merge this PR → version bump runs → version bump PR merged → deploy triggers

Generated with [Claude Code](https://claude.com/claude-code)