### PR TITLE
feat: Add project hierarchy with up to 3 levels of nesting

### DIFF
--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -241,23 +241,25 @@ const tools = [
   },
   {
     name: 'list_projects',
-    description: 'List all projects, optionally filtered by area',
+    description: 'List all projects, optionally filtered by area or parent project',
     inputSchema: {
       type: 'object',
       properties: {
-        area_id: { type: 'string', description: 'Filter by area ID (optional)' }
+        area_id: { type: 'string', description: 'Filter by area ID (optional)' },
+        parent_id: { type: 'string', description: 'Filter by parent project ID (optional, use "null" for root projects only)' }
       }
     }
   },
   {
     name: 'create_project',
-    description: 'Create a new project',
+    description: 'Create a new project or subproject (max 3 levels of nesting)',
     inputSchema: {
       type: 'object',
       properties: {
         name: { type: 'string', description: 'Project name' },
         color: { type: 'string', description: 'Hex color code (optional, e.g., #3498db)' },
-        area_id: { type: 'string', description: 'Area ID to assign project to (optional)' }
+        area_id: { type: 'string', description: 'Area ID to assign project to (optional)' },
+        parent_id: { type: 'string', description: 'Parent project ID to create as subproject (optional)' }
       },
       required: ['name']
     }
@@ -271,18 +273,19 @@ const tools = [
         id: { type: 'string', description: 'Project ID' },
         name: { type: 'string', description: 'New project name (optional)' },
         color: { type: 'string', description: 'New hex color code (optional)' },
-        area_id: { type: 'string', description: 'Area ID (optional, use null to remove)' }
+        area_id: { type: 'string', description: 'Area ID (optional, use null to remove)' },
+        parent_id: { type: 'string', description: 'Parent project ID (optional, use null to move to root)' }
       },
       required: ['id']
     }
   },
   {
     name: 'delete_project',
-    description: 'Delete a project',
+    description: 'Delete a project and all its subprojects',
     inputSchema: {
       type: 'object',
       properties: {
-        id: { type: 'string', description: 'Project ID to delete' }
+        id: { type: 'string', description: 'Project ID to delete (cascades to subprojects)' }
       },
       required: ['id']
     }
@@ -575,10 +578,18 @@ async function handleListProjects(args) {
     .from('projects')
     .select('*')
     .eq('user_id', currentUser.id)
-    .order('created_at', { ascending: false });
+    .order('sort_order', { ascending: true });
 
   if (args.area_id) {
     query = query.eq('area_id', args.area_id);
+  }
+
+  if (args.parent_id !== undefined) {
+    if (args.parent_id === 'null' || args.parent_id === null) {
+      query = query.is('parent_id', null);
+    } else {
+      query = query.eq('parent_id', args.parent_id);
+    }
   }
 
   const { data, error } = await query;
@@ -587,10 +598,11 @@ async function handleListProjects(args) {
     return { success: false, error: error.message };
   }
 
-  // Decrypt project names
+  // Decrypt project names and descriptions
   const projects = await Promise.all(data.map(async (project) => ({
     ...project,
-    name: await decrypt(project.name)
+    name: await decrypt(project.name),
+    description: project.description ? await decrypt(project.description) : null
   })));
 
   return { success: true, projects, count: projects.length };
@@ -608,6 +620,10 @@ async function handleCreateProject(args) {
     color: args.color || randomColor,
     area_id: args.area_id || null
   };
+
+  if (args.parent_id) {
+    projectData.parent_id = args.parent_id;
+  }
 
   const { data, error } = await supabase
     .from('projects')
@@ -639,6 +655,9 @@ async function handleUpdateProject(args) {
   }
   if (args.area_id !== undefined) {
     updateData.area_id = args.area_id;
+  }
+  if (args.parent_id !== undefined) {
+    updateData.parent_id = args.parent_id;
   }
 
   const { data, error } = await supabase
@@ -673,7 +692,7 @@ async function handleDeleteProject(args) {
     return { success: false, error: error.message };
   }
 
-  return { success: true, message: 'Project deleted successfully' };
+  return { success: true, message: 'Project and all subprojects deleted successfully' };
 }
 
 async function handleListAreas() {

--- a/migrations/015_add_project_hierarchy.sql
+++ b/migrations/015_add_project_hierarchy.sql
@@ -1,0 +1,8 @@
+-- Migration 015: Add project hierarchy support
+-- Adds parent_id column to projects table for parent-child relationships (max 3 levels)
+
+-- Add parent_id column for project hierarchy
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS parent_id UUID REFERENCES projects(id) ON DELETE CASCADE;
+
+-- Index for efficient child lookups
+CREATE INDEX IF NOT EXISTS idx_projects_parent_id ON projects(parent_id);

--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -178,10 +178,19 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.manage-projects-color/,
     // Area color indicators (rendered by JavaScript)
     /\.area-color-dot/,
-    // Project title header (rendered by JavaScript)
+    // Project tree hierarchy (rendered by JavaScript)
+    /\.project-expand/,
+    /\.project-expand-spacer/,
+    /\.project-context-menu/,
+    /\.context-menu-item/,
+    // Project title header and breadcrumb (rendered by JavaScript)
     /\.project-title-header/,
     /\.project-title-text/,
     /\.project-title-description/,
+    /\.project-title-breadcrumb/,
+    /\.project-breadcrumb-link/,
+    /\.project-breadcrumb-separator/,
+    /\.project-breadcrumb-current/,
     // Area shortcut hints (rendered by JavaScript for dynamic areas)
     /\.areas-item-shortcut/,
     // Empty/loading states (rendered by JavaScript)

--- a/src/services/export.js
+++ b/src/services/export.js
@@ -1,4 +1,16 @@
 import { store } from '../core/store.js'
+import { getProjectPath } from './projects.js'
+
+/**
+ * Get the full hierarchy path name for a project (e.g., "Parent > Child > Grandchild")
+ * @param {string} projectId - Project ID
+ * @returns {string|null} Full path name or null if not found
+ */
+function getProjectPathName(projectId) {
+    const path = getProjectPath(projectId)
+    if (path.length === 0) return null
+    return path.map(p => p.name).join(' > ')
+}
 
 /**
  * Get human-readable view name for export header
@@ -41,9 +53,9 @@ export function getExportViewName() {
 
     // Project
     if (state.selectedProjectId) {
-        const project = state.projects.find(p => p.id === state.selectedProjectId)
-        if (project) {
-            parts.push(`Project: ${project.name}`)
+        const projectName = getProjectPathName(state.selectedProjectId)
+        if (projectName) {
+            parts.push(`Project: ${projectName}`)
         }
     }
 
@@ -119,9 +131,9 @@ export function exportTodosAsText(filteredTodos) {
             meta.push(`Category: ${category.name}`)
         }
 
-        const project = todo.project_id ? state.projects.find(p => p.id === todo.project_id) : null
-        if (project) {
-            meta.push(`Project: ${project.name}`)
+        const projectName = todo.project_id ? getProjectPathName(todo.project_id) : null
+        if (projectName) {
+            meta.push(`Project: ${projectName}`)
         }
 
         const context = todo.context_id ? state.contexts.find(c => c.id === todo.context_id) : null
@@ -177,7 +189,7 @@ export function exportTodosAsJSON(filteredTodos) {
         },
         todos: filteredTodos.map(todo => {
             const category = todo.category_id ? state.categories.find(c => c.id === todo.category_id) : null
-            const project = todo.project_id ? state.projects.find(p => p.id === todo.project_id) : null
+            const projectName = todo.project_id ? getProjectPathName(todo.project_id) : null
             const context = todo.context_id ? state.contexts.find(c => c.id === todo.context_id) : null
             const priority = todo.priority_id ? state.priorities.find(p => p.id === todo.priority_id) : null
 
@@ -188,7 +200,7 @@ export function exportTodosAsJSON(filteredTodos) {
                 gtdStatus: todo.gtd_status,
                 dueDate: todo.due_date || null,
                 category: category ? category.name : null,
-                project: project ? project.name : null,
+                project: projectName,
                 context: context ? context.name : null,
                 priority: priority ? priority.name : null,
                 comment: todo.comment || null,
@@ -230,7 +242,7 @@ export function exportTodosAsCSV(filteredTodos) {
     // CSV rows
     filteredTodos.forEach(todo => {
         const category = todo.category_id ? state.categories.find(c => c.id === todo.category_id) : null
-        const project = todo.project_id ? state.projects.find(p => p.id === todo.project_id) : null
+        const projectName = todo.project_id ? getProjectPathName(todo.project_id) : null
         const context = todo.context_id ? state.contexts.find(c => c.id === todo.context_id) : null
         const priority = todo.priority_id ? state.priorities.find(p => p.id === todo.priority_id) : null
 
@@ -241,7 +253,7 @@ export function exportTodosAsCSV(filteredTodos) {
             escapeCSV(todo.gtd_status),
             escapeCSV(todo.due_date),
             escapeCSV(category ? category.name : ''),
-            escapeCSV(project ? project.name : ''),
+            escapeCSV(projectName || ''),
             escapeCSV(context ? context.name : ''),
             escapeCSV(priority ? priority.name : ''),
             escapeCSV(todo.comment),
@@ -289,7 +301,7 @@ export function exportTodosAsXML(filteredTodos) {
 
     filteredTodos.forEach(todo => {
         const category = todo.category_id ? state.categories.find(c => c.id === todo.category_id) : null
-        const project = todo.project_id ? state.projects.find(p => p.id === todo.project_id) : null
+        const projectName = todo.project_id ? getProjectPathName(todo.project_id) : null
         const context = todo.context_id ? state.contexts.find(c => c.id === todo.context_id) : null
         const priority = todo.priority_id ? state.priorities.find(p => p.id === todo.priority_id) : null
 
@@ -304,8 +316,8 @@ export function exportTodosAsXML(filteredTodos) {
         if (category) {
             xmlLines.push(`      <category>${escapeXML(category.name)}</category>`)
         }
-        if (project) {
-            xmlLines.push(`      <project>${escapeXML(project.name)}</project>`)
+        if (projectName) {
+            xmlLines.push(`      <project>${escapeXML(projectName)}</project>`)
         }
         if (context) {
             xmlLines.push(`      <context>${escapeXML(context.name)}</context>`)

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -5,6 +5,69 @@ import { encrypt, decrypt } from './auth.js'
 import { pushNavigationState } from './navigation.js'
 
 /**
+ * Get the depth of a project (0 = root, 1 = child, 2 = grandchild)
+ * @param {string} projectId - Project ID
+ * @returns {number} Depth level
+ */
+export function getProjectDepth(projectId) {
+    const projects = store.get('projects')
+    let depth = 0
+    let current = projects.find(p => p.id === projectId)
+    while (current && current.parent_id) {
+        depth++
+        current = projects.find(p => p.id === current.parent_id)
+        if (depth > 3) break // safety guard
+    }
+    return depth
+}
+
+/**
+ * Get all descendant IDs of a project (children, grandchildren)
+ * @param {string} projectId - Project ID
+ * @returns {Array<string>} Array of descendant project IDs
+ */
+export function getDescendantIds(projectId) {
+    const projects = store.get('projects')
+    const ids = []
+    const collect = (pid) => {
+        projects.filter(p => p.parent_id === pid).forEach(child => {
+            ids.push(child.id)
+            collect(child.id)
+        })
+    }
+    collect(projectId)
+    return ids
+}
+
+/**
+ * Check if moving projectId under newParentId would create a cycle
+ * @param {string} projectId - Project being moved
+ * @param {string|null} newParentId - Proposed parent
+ * @returns {boolean} True if it would create a cycle
+ */
+export function wouldCreateCycle(projectId, newParentId) {
+    if (!newParentId) return false
+    if (newParentId === projectId) return true
+    return getDescendantIds(projectId).includes(newParentId)
+}
+
+/**
+ * Get the full path of project names from root to this project
+ * @param {string} projectId - Project ID
+ * @returns {Array<Object>} Array of {id, name} from root to project
+ */
+export function getProjectPath(projectId) {
+    const projects = store.get('projects')
+    const path = []
+    let current = projects.find(p => p.id === projectId)
+    while (current) {
+        path.unshift({ id: current.id, name: current.name })
+        current = current.parent_id ? projects.find(p => p.id === current.parent_id) : null
+    }
+    return path
+}
+
+/**
  * Load all projects for the current user
  * @returns {Promise<Array>} Array of decrypted projects
  */
@@ -34,37 +97,61 @@ export async function loadProjects() {
 /**
  * Add a new project
  * @param {string} name - Project name
+ * @param {string|null} [parentId=null] - Parent project ID for subprojects
  * @returns {Promise<Object>} The created project
  */
-export async function addProject(name) {
+export async function addProject(name, parentId = null) {
     const currentUser = store.get('currentUser')
     const selectedAreaId = store.get('selectedAreaId')
     const projects = store.get('projects')
 
-    // Get next sort order
-    const maxSortOrder = projects.reduce((max, p) => Math.max(max, p.sort_order || 0), 0)
+    // Validate depth limit (max 3 levels: 0, 1, 2)
+    if (parentId) {
+        const parentDepth = getProjectDepth(parentId)
+        if (parentDepth >= 2) {
+            throw new Error('Cannot create subproject: maximum nesting depth (3 levels) reached')
+        }
+    }
+
+    // Get next sort order among siblings
+    const siblings = projects.filter(p => (p.parent_id || null) === parentId)
+    const maxSortOrder = siblings.reduce((max, p) => Math.max(max, p.sort_order || 0), 0)
 
     // Encrypt project name before storing
     const encryptedName = await encrypt(name)
 
-    // Generate a random color
+    // Generate a random color, or inherit from parent
     const colors = ['#667eea', '#764ba2', '#f093fb', '#f5576c', '#4facfe', '#00f2fe', '#43e97b', '#38f9d7', '#fa709a', '#fee140']
-    const randomColor = colors[Math.floor(Math.random() * colors.length)]
+    let projectColor
+    let areaId
 
-    // Assign to current area if a specific area is selected
-    const areaId = (selectedAreaId !== 'all' && selectedAreaId !== 'unassigned')
-        ? selectedAreaId
-        : null
+    if (parentId) {
+        // Inherit color and area from parent
+        const parent = projects.find(p => p.id === parentId)
+        projectColor = parent ? parent.color : colors[Math.floor(Math.random() * colors.length)]
+        areaId = parent ? parent.area_id : null
+    } else {
+        projectColor = colors[Math.floor(Math.random() * colors.length)]
+        // Assign to current area if a specific area is selected
+        areaId = (selectedAreaId !== 'all' && selectedAreaId !== 'unassigned')
+            ? selectedAreaId
+            : null
+    }
+
+    const insertData = {
+        user_id: currentUser.id,
+        name: encryptedName,
+        color: projectColor,
+        area_id: areaId,
+        sort_order: maxSortOrder + 1
+    }
+    if (parentId) {
+        insertData.parent_id = parentId
+    }
 
     const { data, error } = await supabase
         .from('projects')
-        .insert({
-            user_id: currentUser.id,
-            name: encryptedName,
-            color: randomColor,
-            area_id: areaId,
-            sort_order: maxSortOrder + 1
-        })
+        .insert(insertData)
         .select()
 
     if (error) {
@@ -81,10 +168,12 @@ export async function addProject(name) {
 }
 
 /**
- * Delete a project
+ * Delete a project and all its descendants
  * @param {string} projectId - Project ID
  */
 export async function deleteProject(projectId) {
+    const descendantIds = getDescendantIds(projectId)
+
     const { error } = await supabase
         .from('projects')
         .delete()
@@ -95,11 +184,13 @@ export async function deleteProject(projectId) {
         throw error
     }
 
-    const projects = store.get('projects').filter(p => p.id !== projectId)
+    // Remove project and all descendants from local store
+    const removedIds = new Set([projectId, ...descendantIds])
+    const projects = store.get('projects').filter(p => !removedIds.has(p.id))
     store.set('projects', projects)
 
-    // Clear selection if deleted project was selected
-    if (store.get('selectedProjectId') === projectId) {
+    // Clear selection if deleted project or any descendant was selected
+    if (removedIds.has(store.get('selectedProjectId'))) {
         store.set('selectedProjectId', null)
     }
 
@@ -146,13 +237,14 @@ export function getFilteredProjects() {
 }
 
 /**
- * Update a project (name, color, description, area_id)
+ * Update a project (name, color, description, area_id, parent_id)
  * @param {string} projectId - Project ID
  * @param {Object} updates - Fields to update
  * @param {string} [updates.name] - New project name
  * @param {string} [updates.color] - New project color
  * @param {string} [updates.description] - New project description
  * @param {string|null} [updates.area_id] - New area ID or null
+ * @param {string|null} [updates.parent_id] - New parent project ID or null
  */
 export async function updateProject(projectId, updates) {
     const updateData = {}
@@ -168,6 +260,32 @@ export async function updateProject(projectId, updates) {
     }
     if (updates.area_id !== undefined) {
         updateData.area_id = updates.area_id
+
+        // Propagate area change to all descendants
+        const descendantIds = getDescendantIds(projectId)
+        if (descendantIds.length > 0) {
+            for (const childId of descendantIds) {
+                await supabase
+                    .from('projects')
+                    .update({ area_id: updates.area_id })
+                    .eq('id', childId)
+            }
+        }
+    }
+    if (updates.parent_id !== undefined) {
+        // Validate no circular reference
+        if (wouldCreateCycle(projectId, updates.parent_id)) {
+            throw new Error('Cannot move project: would create circular reference')
+        }
+        // Validate depth limit
+        if (updates.parent_id) {
+            const parentDepth = getProjectDepth(updates.parent_id)
+            const subtreeDepth = getMaxSubtreeDepth(projectId)
+            if (parentDepth + 1 + subtreeDepth > 2) {
+                throw new Error('Cannot move project: would exceed maximum nesting depth (3 levels)')
+            }
+        }
+        updateData.parent_id = updates.parent_id
     }
 
     const { error } = await supabase
@@ -187,11 +305,32 @@ export async function updateProject(projectId, updates) {
         if (updates.name !== undefined) project.name = updates.name
         if (updates.color !== undefined) project.color = updates.color
         if (updates.description !== undefined) project.description = updates.description
-        if (updates.area_id !== undefined) project.area_id = updates.area_id
+        if (updates.area_id !== undefined) {
+            project.area_id = updates.area_id
+            // Update descendants locally too
+            const descendantIds = getDescendantIds(projectId)
+            descendantIds.forEach(id => {
+                const child = projects.find(p => p.id === id)
+                if (child) child.area_id = updates.area_id
+            })
+        }
+        if (updates.parent_id !== undefined) project.parent_id = updates.parent_id
         store.set('projects', [...projects])
     }
 
     events.emit(Events.PROJECT_UPDATED, project)
+}
+
+/**
+ * Get the maximum depth of a project's subtree (0 if no children)
+ * @param {string} projectId - Project ID
+ * @returns {number} Maximum subtree depth
+ */
+function getMaxSubtreeDepth(projectId) {
+    const projects = store.get('projects')
+    const children = projects.filter(p => p.parent_id === projectId)
+    if (children.length === 0) return 0
+    return 1 + Math.max(...children.map(c => getMaxSubtreeDepth(c.id)))
 }
 
 /**
@@ -204,18 +343,21 @@ export async function renameProject(projectId, newName) {
 }
 
 /**
- * Reorder projects
+ * Reorder projects (among siblings with same parent)
  * @param {Array<string>} orderedIds - Array of project IDs in new order
  */
 export async function reorderProjects(orderedIds) {
     const projects = store.get('projects')
 
     // Update local state first for immediate feedback
-    const reorderedProjects = orderedIds.map((id, index) => {
-        const project = projects.find(p => p.id === id)
-        return { ...project, sort_order: index }
+    const updatedProjects = projects.map(p => {
+        const index = orderedIds.indexOf(p.id)
+        if (index !== -1) {
+            return { ...p, sort_order: index }
+        }
+        return p
     })
-    store.set('projects', reorderedProjects)
+    store.set('projects', updatedProjects)
 
     // Update database
     for (let i = 0; i < orderedIds.length; i++) {

--- a/src/services/todos-filters.js
+++ b/src/services/todos-filters.js
@@ -104,13 +104,25 @@ export function getFilteredTodos() {
 }
 
 /**
- * Get todo count for a project (excluding done items)
+ * Get todo count for a project including all descendant projects (excluding done items)
  * @param {string} projectId - Project ID
  * @returns {number} Todo count
  */
 export function getProjectTodoCount(projectId) {
     const todos = store.get('todos')
-    return todos.filter(t => t.project_id === projectId && t.gtd_status !== 'done').length
+    const projects = store.get('projects')
+
+    // Collect this project + all descendant IDs
+    const ids = [projectId]
+    const collect = (pid) => {
+        projects.filter(p => p.parent_id === pid).forEach(child => {
+            ids.push(child.id)
+            collect(child.id)
+        })
+    }
+    collect(projectId)
+
+    return todos.filter(t => ids.includes(t.project_id) && t.gtd_status !== 'done').length
 }
 
 /**

--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -1,12 +1,14 @@
 import { store } from '../core/store.js'
 import { escapeHtml, validateColor } from '../utils/security.js'
-import { getFilteredProjects, selectProject, deleteProject, updateProject, reorderProjects } from '../services/projects.js'
+import { getFilteredProjects, selectProject, deleteProject, addProject, updateProject, reorderProjects, getDescendantIds } from '../services/projects.js'
 import { getProjectTodoCount, updateTodoProject } from '../services/todos.js'
 import { getIcon } from '../utils/icons.js'
-import { populateSelectOptions } from './helpers.js'
+
+// Track collapsed state for project tree nodes (not persisted)
+const collapsedProjects = new Set()
 
 /**
- * Render the project list in the sidebar
+ * Render the project list in the sidebar as a tree
  * @param {HTMLElement} container - Container element
  */
 export function renderProjects(container) {
@@ -45,13 +47,46 @@ export function renderProjects(container) {
     })
     container.appendChild(allItem)
 
-    // Add user projects (filtered by area)
-    filteredProjects.forEach(project => {
+    // Render project tree recursively
+    renderProjectTree(container, filteredProjects, null, 0)
+}
+
+/**
+ * Recursively render project tree nodes
+ * @param {HTMLElement} container - Container element
+ * @param {Array} projects - All projects (flat, filtered by area)
+ * @param {string|null} parentId - Parent project ID (null for roots)
+ * @param {number} depth - Current depth level
+ */
+function renderProjectTree(container, projects, parentId, depth) {
+    const state = store.state
+    const children = projects
+        .filter(p => (p.parent_id || null) === parentId)
+        .sort((a, b) => (a.sort_order || 0) - (b.sort_order || 0))
+
+    children.forEach(project => {
         const li = document.createElement('li')
         li.className = `project-item ${state.selectedProjectId === project.id ? 'active' : ''}`
+        li.style.paddingLeft = `${12 + depth * 20}px`
+        li.dataset.projectId = project.id
+        li.dataset.depth = depth
+
         const count = getProjectTodoCount(project.id)
         const countDisplay = count > 0 ? count : ''
+
+        const hasChildren = projects.some(p => p.parent_id === project.id)
+        const isCollapsed = collapsedProjects.has(project.id)
+
+        let expandHtml
+        if (hasChildren) {
+            const chevronClass = isCollapsed ? 'collapsed' : ''
+            expandHtml = `<span class="project-expand ${chevronClass}">${getIcon('chevron-down', { size: 12 })}</span>`
+        } else {
+            expandHtml = '<span class="project-expand-spacer"></span>'
+        }
+
         li.innerHTML = `
+            ${expandHtml}
             <span class="project-name">
                 <span class="project-color" style="background-color: ${validateColor(project.color)}"></span>
                 ${escapeHtml(project.name)}
@@ -60,10 +95,31 @@ export function renderProjects(container) {
             <button class="project-delete" data-id="${project.id}">${getIcon('x', { size: 12 })}</button>
         `
 
+        // Expand/collapse toggle
+        if (hasChildren) {
+            const expandBtn = li.querySelector('.project-expand')
+            expandBtn.addEventListener('click', (e) => {
+                e.stopPropagation()
+                if (collapsedProjects.has(project.id)) {
+                    collapsedProjects.delete(project.id)
+                } else {
+                    collapsedProjects.add(project.id)
+                }
+                renderProjects(container)
+            })
+        }
+
+        // Click to select project
         li.addEventListener('click', (e) => {
-            if (!e.target.classList.contains('project-delete')) {
+            if (!e.target.closest('.project-delete') && !e.target.closest('.project-expand')) {
                 selectProject(project.id)
             }
+        })
+
+        // Right-click context menu
+        li.addEventListener('contextmenu', (e) => {
+            e.preventDefault()
+            showProjectContextMenu(e, project, depth, container)
         })
 
         // Drop target for assigning project
@@ -84,24 +140,147 @@ export function renderProjects(container) {
             }
         })
 
+        // Delete button
         const deleteBtn = li.querySelector('.project-delete')
         deleteBtn.addEventListener('click', async (e) => {
             e.stopPropagation()
-            if (confirm('Delete this project? Todos in this project will become projectless.')) {
+            const descendantCount = getDescendantIds(project.id).length
+            const msg = descendantCount > 0
+                ? `Delete "${project.name}" and its ${descendantCount} subproject(s)? Todos in these projects will become projectless.`
+                : `Delete "${project.name}"? Todos in this project will become projectless.`
+            if (confirm(msg)) {
                 await deleteProject(project.id)
             }
         })
 
         container.appendChild(li)
+
+        // Render children recursively (if not collapsed)
+        if (hasChildren && !isCollapsed) {
+            renderProjectTree(container, projects, project.id, depth + 1)
+        }
     })
 }
 
 /**
- * Update the project select dropdown
+ * Show context menu for a project
+ * @param {MouseEvent} event - Right-click event
+ * @param {Object} project - Project object
+ * @param {number} depth - Current depth level
+ * @param {HTMLElement} projectContainer - The project list container for re-rendering
+ */
+function showProjectContextMenu(event, project, depth, projectContainer) {
+    // Remove any existing context menu
+    document.querySelector('.project-context-menu')?.remove()
+
+    const menu = document.createElement('div')
+    menu.className = 'project-context-menu'
+    menu.setAttribute('role', 'menu')
+
+    // "Add subproject" option (only if depth < 2, max 3 levels)
+    if (depth < 2) {
+        const addSubItem = document.createElement('div')
+        addSubItem.className = 'context-menu-item'
+        addSubItem.setAttribute('role', 'menuitem')
+        addSubItem.innerHTML = `${getIcon('plus', { size: 14 })} Add subproject`
+        addSubItem.addEventListener('click', async () => {
+            menu.remove()
+            const name = prompt('Subproject name:')
+            if (name && name.trim()) {
+                try {
+                    await addProject(name.trim(), project.id)
+                    // Ensure parent is expanded
+                    collapsedProjects.delete(project.id)
+                } catch (err) {
+                    alert(err.message)
+                }
+            }
+        })
+        menu.appendChild(addSubItem)
+    }
+
+    // "Delete" option
+    const deleteItem = document.createElement('div')
+    deleteItem.className = 'context-menu-item context-menu-item-danger'
+    deleteItem.setAttribute('role', 'menuitem')
+    const descendantCount = getDescendantIds(project.id).length
+    deleteItem.innerHTML = `${getIcon('x', { size: 14 })} Delete project`
+    deleteItem.addEventListener('click', async () => {
+        menu.remove()
+        const msg = descendantCount > 0
+            ? `Delete "${project.name}" and its ${descendantCount} subproject(s)? Todos in these projects will become projectless.`
+            : `Delete "${project.name}"? Todos in this project will become projectless.`
+        if (confirm(msg)) {
+            await deleteProject(project.id)
+        }
+    })
+    menu.appendChild(deleteItem)
+
+    // Position menu at cursor, clamped to viewport
+    menu.style.left = `${event.clientX}px`
+    menu.style.top = `${event.clientY}px`
+    document.body.appendChild(menu)
+
+    // Adjust position if menu overflows viewport
+    requestAnimationFrame(() => {
+        const rect = menu.getBoundingClientRect()
+        if (rect.right > window.innerWidth) {
+            menu.style.left = `${window.innerWidth - rect.width - 8}px`
+        }
+        if (rect.bottom > window.innerHeight) {
+            menu.style.top = `${window.innerHeight - rect.height - 8}px`
+        }
+    })
+
+    // Close on click outside
+    const closeMenu = (e) => {
+        if (!menu.contains(e.target)) {
+            menu.remove()
+            document.removeEventListener('click', closeMenu)
+            document.removeEventListener('contextmenu', closeMenu)
+        }
+    }
+    setTimeout(() => {
+        document.addEventListener('click', closeMenu)
+        document.addEventListener('contextmenu', closeMenu)
+    }, 0)
+}
+
+/**
+ * Update a project select dropdown with hierarchical options
  * @param {HTMLSelectElement} selectElement - Select element
  */
 export function updateProjectSelect(selectElement) {
-    populateSelectOptions(selectElement, store.get('projects'), { emptyLabel: 'No Project' })
+    const projects = store.get('projects')
+    selectElement.innerHTML = ''
+
+    const emptyOption = document.createElement('option')
+    emptyOption.value = ''
+    emptyOption.textContent = 'No Project'
+    selectElement.appendChild(emptyOption)
+
+    addHierarchicalOptions(selectElement, projects, null, 0)
+}
+
+/**
+ * Add hierarchical options to a select element
+ * @param {HTMLSelectElement} selectElement - Select element
+ * @param {Array} projects - All projects
+ * @param {string|null} parentId - Parent ID filter
+ * @param {number} depth - Indentation depth
+ */
+function addHierarchicalOptions(selectElement, projects, parentId, depth) {
+    const children = projects
+        .filter(p => (p.parent_id || null) === parentId)
+        .sort((a, b) => (a.sort_order || 0) - (b.sort_order || 0))
+
+    children.forEach(project => {
+        const option = document.createElement('option')
+        option.value = project.id
+        option.textContent = '\u00A0\u00A0'.repeat(depth) + project.name
+        selectElement.appendChild(option)
+        addHierarchicalOptions(selectElement, projects, project.id, depth + 1)
+    })
 }
 
 /**
@@ -113,11 +292,30 @@ export function renderManageProjectsList(container) {
     const areas = store.get('areas')
     container.innerHTML = ''
 
-    projects.forEach(project => {
+    renderManageProjectsTree(container, projects, areas, null, 0)
+}
+
+/**
+ * Recursively render manage projects tree
+ * @param {HTMLElement} container - Container element
+ * @param {Array} projects - All projects
+ * @param {Array} areas - All areas
+ * @param {string|null} parentId - Parent project ID
+ * @param {number} depth - Current depth level
+ */
+function renderManageProjectsTree(container, projects, areas, parentId, depth) {
+    const children = projects
+        .filter(p => (p.parent_id || null) === parentId)
+        .sort((a, b) => (a.sort_order || 0) - (b.sort_order || 0))
+
+    children.forEach(project => {
         const li = document.createElement('li')
         li.className = 'manage-projects-item'
         li.dataset.projectId = project.id
+        li.dataset.parentId = parentId || ''
+        li.dataset.depth = depth
         li.draggable = true
+        li.style.paddingLeft = `${12 + depth * 24}px`
         const projectColor = project.color || '#667eea'
         const descriptionHtml = project.description
             ? `<span class="manage-projects-description">${escapeHtml(project.description)}</span>`
@@ -144,9 +342,10 @@ export function renderManageProjectsList(container) {
             </div>
         `
 
-        // Drag events for reordering
+        // Drag events for reordering (scoped to siblings)
         li.addEventListener('dragstart', (e) => {
             e.dataTransfer.setData('text/plain', project.id)
+            e.dataTransfer.setData('application/x-parent-id', parentId || '')
             li.classList.add('dragging')
         })
         li.addEventListener('dragend', () => {
@@ -159,7 +358,11 @@ export function renderManageProjectsList(container) {
             e.preventDefault()
             const dragging = container.querySelector('.dragging')
             if (dragging && dragging !== li) {
-                li.classList.add('drag-over')
+                // Only allow reordering among siblings
+                const dragParentId = dragging.dataset.parentId
+                if (dragParentId === li.dataset.parentId) {
+                    li.classList.add('drag-over')
+                }
             }
         })
         li.addEventListener('dragleave', () => {
@@ -170,6 +373,10 @@ export function renderManageProjectsList(container) {
             li.classList.remove('drag-over')
             const dragging = container.querySelector('.dragging')
             if (dragging && dragging !== li) {
+                // Only reorder among siblings
+                const dragParentId = dragging.dataset.parentId
+                if (dragParentId !== li.dataset.parentId) return
+
                 const rect = li.getBoundingClientRect()
                 const midY = rect.top + rect.height / 2
                 if (e.clientY < midY) {
@@ -177,7 +384,9 @@ export function renderManageProjectsList(container) {
                 } else {
                     li.after(dragging)
                 }
-                const orderedIds = [...container.querySelectorAll('.manage-projects-item')]
+                // Collect sibling IDs in new order
+                const siblingParentId = dragParentId || ''
+                const orderedIds = [...container.querySelectorAll(`.manage-projects-item[data-parent-id="${siblingParentId}"]`)]
                     .map(item => item.dataset.projectId)
                 await reorderProjects(orderedIds)
             }
@@ -223,13 +432,20 @@ export function renderManageProjectsList(container) {
         // Delete button
         li.querySelector('.manage-projects-delete').addEventListener('click', async (e) => {
             e.stopPropagation()
-            if (confirm(`Delete "${project.name}"? Todos in this project will become projectless.`)) {
+            const descendantCount = getDescendantIds(project.id).length
+            const msg = descendantCount > 0
+                ? `Delete "${project.name}" and its ${descendantCount} subproject(s)? Todos in these projects will become projectless.`
+                : `Delete "${project.name}"? Todos in this project will become projectless.`
+            if (confirm(msg)) {
                 await deleteProject(project.id)
                 renderManageProjectsList(container)
             }
         })
 
         container.appendChild(li)
+
+        // Render children recursively
+        renderManageProjectsTree(container, projects, areas, project.id, depth + 1)
     })
 }
 

--- a/src/ui/SelectionBar.js
+++ b/src/ui/SelectionBar.js
@@ -189,12 +189,28 @@ export function updateSelectionBarProjectSelect(selectElement) {
     noProjectOption.textContent = 'No Project'
     selectElement.appendChild(noProjectOption)
 
-    // Add project options
-    projects.forEach(project => {
+    // Add project options hierarchically
+    addHierarchicalProjectOptions(selectElement, projects, null, 0)
+}
+
+/**
+ * Recursively add hierarchical project options to a select element
+ * @param {HTMLSelectElement} selectElement - Select element
+ * @param {Array} projects - All projects
+ * @param {string|null} parentId - Parent ID filter
+ * @param {number} depth - Indentation depth
+ */
+function addHierarchicalProjectOptions(selectElement, projects, parentId, depth) {
+    const children = projects
+        .filter(p => (p.parent_id || null) === parentId)
+        .sort((a, b) => (a.sort_order || 0) - (b.sort_order || 0))
+
+    children.forEach(project => {
         const option = document.createElement('option')
         option.value = project.id
-        option.textContent = project.name
+        option.textContent = '\u00A0\u00A0'.repeat(depth) + project.name
         selectElement.appendChild(option)
+        addHierarchicalProjectOptions(selectElement, projects, project.id, depth + 1)
     })
 }
 

--- a/src/ui/TodoList.js
+++ b/src/ui/TodoList.js
@@ -2,6 +2,7 @@ import { store } from '../core/store.js'
 import { escapeHtml, validateColor } from '../utils/security.js'
 import { formatDateBadge, getDateGroup, getDateGroupLabel } from '../utils/dates.js'
 import { getFilteredTodos, toggleTodo, deleteTodo, updateTodoProject, updateTodoGtdStatus, getProjectTodoCount, toggleTodoSelection, selectTodoRange } from '../services/todos.js'
+import { getProjectPath, selectProject } from '../services/projects.js'
 import { getCategoryById } from '../services/categories.js'
 import { getPriorityById } from '../services/priorities.js'
 import { getContextById } from '../services/contexts.js'
@@ -38,10 +39,29 @@ export function renderProjectsView(container, onProjectClick) {
         return
     }
 
-    projects.forEach(project => {
+    renderProjectCards(container, projects, null, 0, onProjectClick)
+}
+
+/**
+ * Recursively render project cards in the "All Projects" view
+ * @param {HTMLElement} container - Container element
+ * @param {Array} projects - All projects
+ * @param {string|null} parentId - Parent ID filter
+ * @param {number} depth - Current depth
+ * @param {Function} onProjectClick - Click callback
+ */
+function renderProjectCards(container, projects, parentId, depth, onProjectClick) {
+    const children = projects
+        .filter(p => (p.parent_id || null) === parentId)
+        .sort((a, b) => (a.sort_order || 0) - (b.sort_order || 0))
+
+    children.forEach(project => {
         const count = getProjectTodoCount(project.id)
         const li = document.createElement('li')
         li.className = 'project-card'
+        if (depth > 0) {
+            li.style.marginLeft = `${depth * 24}px`
+        }
         li.innerHTML = `
             <span class="project-card-color" style="background-color: ${validateColor(project.color)}"></span>
             <span class="project-card-name">${escapeHtml(project.name)}</span>
@@ -49,6 +69,9 @@ export function renderProjectsView(container, onProjectClick) {
         `
         li.addEventListener('click', () => onProjectClick(project.id))
         container.appendChild(li)
+
+        // Render children
+        renderProjectCards(container, projects, project.id, depth + 1, onProjectClick)
     })
 }
 
@@ -80,10 +103,36 @@ export function renderTodos(container, options = {}) {
             const descriptionHtml = project.description
                 ? `<span class="project-title-description">${escapeHtml(project.description)}</span>`
                 : ''
+
+            // Build breadcrumb for subprojects
+            const path = getProjectPath(project.id)
+            let titleHtml
+            if (path.length > 1) {
+                // Show breadcrumb: Parent > Child > Current
+                const breadcrumbParts = path.map((p, i) => {
+                    if (i < path.length - 1) {
+                        return `<span class="project-breadcrumb-link" data-project-id="${p.id}">${escapeHtml(p.name)}</span>`
+                    }
+                    return `<span class="project-breadcrumb-current">${escapeHtml(p.name)}</span>`
+                })
+                titleHtml = `<span class="project-title-breadcrumb">${breadcrumbParts.join('<span class="project-breadcrumb-separator"> / </span>')}</span>`
+            } else {
+                titleHtml = `<span class="project-title-text">${escapeHtml(project.name)}</span>`
+            }
+
             header.innerHTML = `
-                <span class="project-title-text">${escapeHtml(project.name)}</span>
+                ${titleHtml}
                 ${descriptionHtml}
             `
+
+            // Add click handlers for breadcrumb links
+            header.querySelectorAll('.project-breadcrumb-link').forEach(link => {
+                link.addEventListener('click', (e) => {
+                    e.stopPropagation()
+                    selectProject(link.dataset.projectId)
+                })
+            })
+
             container.appendChild(header)
         }
     }

--- a/src/ui/modals/ImportModal.js
+++ b/src/ui/modals/ImportModal.js
@@ -1,6 +1,7 @@
 import { store } from '../../core/store.js'
 import { batchAddTodos } from '../../services/todos.js'
 import { populateSelectOptions } from '../helpers.js'
+import { updateProjectSelect as updateProjectSelectHierarchical } from '../ProjectList.js'
 import { BaseModal } from './BaseModal.js'
 
 /**
@@ -129,7 +130,7 @@ export class ImportModal extends BaseModal {
     }
 
     updateProjectSelect() {
-        populateSelectOptions(this.projectSelect, store.get('projects'), { emptyLabel: 'No Project' })
+        updateProjectSelectHierarchical(this.projectSelect)
     }
 
     updateCategorySelect() {

--- a/src/ui/modals/TodoModal.js
+++ b/src/ui/modals/TodoModal.js
@@ -1,6 +1,7 @@
 import { store } from '../../core/store.js'
 import { addTodo, updateTodo, createRecurringTodo, convertToRecurring, updateTemplateRecurrence } from '../../services/todos.js'
 import { populateSelectOptions } from '../helpers.js'
+import { updateProjectSelect as updateProjectSelectHierarchical } from '../ProjectList.js'
 import { RecurrencePanel } from './RecurrencePanel.js'
 import { BaseModal } from './BaseModal.js'
 
@@ -350,6 +351,6 @@ export class TodoModal extends BaseModal {
     }
 
     updateProjectSelect() {
-        populateSelectOptions(this.projectSelect, store.get('projects'), { emptyLabel: 'No Project' })
+        updateProjectSelectHierarchical(this.projectSelect)
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -608,11 +608,48 @@ body.sidebar-resizing * {
     font-weight: 600;
 }
 
+.project-expand {
+    display: inline-flex;
+    width: 16px;
+    height: 16px;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    opacity: 0.5;
+    transition: transform 0.2s, opacity 0.2s;
+    margin-right: 2px;
+}
+
+.project-expand:hover {
+    opacity: 1;
+}
+
+.project-expand.collapsed {
+    transform: rotate(-90deg);
+}
+
+.project-expand svg {
+    width: 12px;
+    height: 12px;
+}
+
+.project-expand-spacer {
+    display: inline-flex;
+    width: 16px;
+    flex-shrink: 0;
+    margin-right: 2px;
+}
+
 .project-name {
     flex: 1;
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .project-color {
@@ -658,6 +695,46 @@ body.sidebar-resizing * {
 
 .project-item.active .project-count {
     color: rgba(255, 255, 255, 0.8);
+}
+
+/* Project context menu */
+.project-context-menu {
+    position: fixed;
+    z-index: 10000;
+    background: var(--bg-primary, #ffffff);
+    border: 1px solid var(--separator-color, #e0e0e0);
+    border-radius: 8px;
+    padding: 4px 0;
+    min-width: 170px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+.context-menu-item {
+    padding: 8px 14px;
+    cursor: pointer;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: background 0.15s;
+}
+
+.context-menu-item:hover {
+    background: var(--bg-hover, #f5f5f5);
+}
+
+.context-menu-item svg {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+}
+
+.context-menu-item-danger {
+    color: #e74c3c;
+}
+
+.context-menu-item-danger:hover {
+    background: rgba(231, 76, 60, 0.1);
 }
 
 .add-project-form {
@@ -954,6 +1031,37 @@ body.sidebar-resizing * {
     font-weight: 600;
     color: white;
     letter-spacing: 0.3px;
+}
+
+.project-title-breadcrumb {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: white;
+    letter-spacing: 0.3px;
+}
+
+.project-breadcrumb-link {
+    opacity: 0.7;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+
+.project-breadcrumb-link:hover {
+    opacity: 1;
+    text-decoration: underline;
+}
+
+.project-breadcrumb-separator {
+    opacity: 0.5;
+    margin: 0 2px;
+}
+
+.project-breadcrumb-current {
+    opacity: 1;
 }
 
 .project-title-description {
@@ -4902,6 +5010,32 @@ body.sidebar-resizing * {
 [data-theme="dark"] .project-item.active .project-count,
 [data-theme="clear"] .project-item.active .project-count {
     color: var(--ios-blue);
+}
+
+[data-theme="glass"] .project-expand,
+[data-theme="dark"] .project-expand,
+[data-theme="clear"] .project-expand {
+    opacity: 0.4;
+}
+
+[data-theme="glass"] .project-expand:hover,
+[data-theme="dark"] .project-expand:hover,
+[data-theme="clear"] .project-expand:hover {
+    opacity: 0.8;
+}
+
+[data-theme="glass"] .project-context-menu,
+[data-theme="dark"] .project-context-menu,
+[data-theme="clear"] .project-context-menu {
+    background: var(--bg-secondary);
+    border-color: var(--separator-color);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="glass"] .context-menu-item:hover,
+[data-theme="dark"] .context-menu-item:hover,
+[data-theme="clear"] .context-menu-item:hover {
+    background: var(--ios-gray6);
 }
 
 [data-theme="glass"] .add-project-form,


### PR DESCRIPTION
## Summary

- Adds `parent_id` column to projects table enabling parent-child tree structure (max 3 levels deep)
- Sidebar renders projects as a collapsible tree with expand/collapse chevrons and indentation
- Right-click context menu on projects to create subprojects
- Parent project todo counts recursively aggregate all descendant counts
- Selecting a parent project shows only its direct todos (click child to see child's todos)
- Breadcrumb navigation in project header for subprojects (e.g., "Parent / Child / Grandchild")
- All project dropdowns (todo modal, import modal, selection bar) show indented hierarchy
- Exports include full hierarchy path (e.g., "Parent > Child > Grandchild")
- MCP server updated with `parent_id` support for create/update/list operations
- Cascade delete: deleting a parent removes all children (with confirmation warning)
- Area inheritance: children inherit parent's area, changes propagate to descendants
- Circular reference and depth limit validation in service layer

## Database Migration

Run `migrations/015_add_project_hierarchy.sql` in Supabase SQL Editor before deploying.

## Test plan

- [ ] Run migration in Supabase SQL Editor
- [ ] Create a root project, right-click to add subproject, right-click subproject to add sub-sub-project
- [ ] Verify "Add subproject" is hidden on 3rd-level projects (depth limit)
- [ ] Verify sidebar shows indented tree with working collapse/expand
- [ ] Verify parent todo count includes descendant todos
- [ ] Verify clicking parent shows only its direct todos
- [ ] Verify deleting a parent removes all children (with warning dialog)
- [ ] Verify breadcrumb path shows and is clickable when viewing a subproject
- [ ] Verify project selects in todo modal, import modal, and selection bar show indented hierarchy
- [ ] Verify exports (text/JSON/CSV/XML) include hierarchy path
- [ ] Verify drag-and-drop todo assignment works on any project level
- [ ] Verify area changes on parent propagate to children
- [ ] Test across themes (Glass, Dark, Clear)
- [ ] Run `npm run check:css` (passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)