### PR TITLE
Add delete-tasks option when deleting a project with tasks

### DIFF
--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -193,6 +193,8 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.project-breadcrumb-current/,
     // Area shortcut hints (rendered by JavaScript for dynamic areas)
     /\.areas-item-shortcut/,
+    // Delete project dialog (rendered by JavaScript)
+    /\.delete-project-dialog/,
     // Toast notifications (rendered by JavaScript)
     /\.toast/,
     /\.toast-visible/,

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -170,9 +170,28 @@ export async function addProject(name, parentId = null) {
 /**
  * Delete a project and all its descendants
  * @param {string} projectId - Project ID
+ * @param {Object} [options] - Delete options
+ * @param {boolean} [options.deleteTodos=false] - Also delete todos in these projects
  */
-export async function deleteProject(projectId) {
+export async function deleteProject(projectId, { deleteTodos = false } = {}) {
     const descendantIds = getDescendantIds(projectId)
+    const removedIds = new Set([projectId, ...descendantIds])
+
+    // Delete todos in these projects if requested
+    if (deleteTodos) {
+        const { error: todosError } = await supabase
+            .from('todos')
+            .delete()
+            .in('project_id', [...removedIds])
+
+        if (todosError) {
+            console.error('Error deleting project todos:', todosError)
+            throw todosError
+        }
+
+        const todos = store.get('todos').filter(t => !removedIds.has(t.project_id))
+        store.set('todos', todos)
+    }
 
     const { error } = await supabase
         .from('projects')
@@ -185,7 +204,6 @@ export async function deleteProject(projectId) {
     }
 
     // Remove project and all descendants from local store
-    const removedIds = new Set([projectId, ...descendantIds])
     const projects = store.get('projects').filter(p => !removedIds.has(p.id))
     store.set('projects', projects)
 

--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -4,6 +4,79 @@ import { getFilteredProjects, selectProject, deleteProject, addProject, updatePr
 import { getProjectTodoCount, updateTodoProject } from '../services/todos.js'
 import { getIcon } from '../utils/icons.js'
 
+/**
+ * Count ALL todos (including done) in a project and its descendants
+ */
+function getAllProjectTodoCount(projectId) {
+    const todos = store.get('todos')
+    const ids = new Set([projectId, ...getDescendantIds(projectId)])
+    return todos.filter(t => ids.has(t.project_id)).length
+}
+
+/**
+ * Show a delete project dialog with options when project has todos.
+ * Returns a promise that resolves to { confirmed, deleteTodos }.
+ */
+function showDeleteProjectDialog(projectName, todoCount, descendantCount) {
+    return new Promise(resolve => {
+        // No todos — use simple confirm
+        if (todoCount === 0) {
+            const msg = descendantCount > 0
+                ? `Delete "${projectName}" and its ${descendantCount} subproject(s)?`
+                : `Delete "${projectName}"?`
+            resolve({ confirmed: confirm(msg), deleteTodos: false })
+            return
+        }
+
+        const overlay = document.createElement('div')
+        overlay.className = 'delete-project-dialog-overlay'
+
+        const projectLabel = descendantCount > 0
+            ? `"${escapeHtml(projectName)}" and its ${descendantCount} subproject(s)`
+            : `"${escapeHtml(projectName)}"`
+
+        overlay.innerHTML = `
+            <div class="delete-project-dialog" role="dialog" aria-modal="true" aria-label="Delete project">
+                <div class="delete-project-dialog-title">Delete ${projectLabel}</div>
+                <p class="delete-project-dialog-text">This project has <strong>${todoCount}</strong> task${todoCount !== 1 ? 's' : ''}. What would you like to do with them?</p>
+                <div class="delete-project-dialog-actions">
+                    <button class="delete-project-dialog-btn delete-project-dialog-btn-keep" data-action="keep">
+                        ${getIcon('x', { size: 16 })}
+                        Remove from project
+                        <span class="delete-project-dialog-btn-desc">Tasks will become projectless</span>
+                    </button>
+                    <button class="delete-project-dialog-btn delete-project-dialog-btn-delete" data-action="delete">
+                        ${getIcon('trash', { size: 16 })}
+                        Delete tasks
+                        <span class="delete-project-dialog-btn-desc">Tasks will be permanently deleted</span>
+                    </button>
+                </div>
+                <button class="delete-project-dialog-cancel" data-action="cancel">Cancel</button>
+            </div>
+        `
+
+        const cleanup = (result) => {
+            overlay.remove()
+            document.removeEventListener('keydown', onKey)
+            resolve(result)
+        }
+
+        const onKey = (e) => {
+            if (e.key === 'Escape') cleanup({ confirmed: false, deleteTodos: false })
+        }
+        document.addEventListener('keydown', onKey)
+
+        overlay.addEventListener('click', (e) => {
+            const action = e.target.closest('[data-action]')?.dataset.action
+            if (action === 'keep') cleanup({ confirmed: true, deleteTodos: false })
+            else if (action === 'delete') cleanup({ confirmed: true, deleteTodos: true })
+            else if (action === 'cancel' || e.target === overlay) cleanup({ confirmed: false, deleteTodos: false })
+        })
+
+        document.body.appendChild(overlay)
+    })
+}
+
 // Track collapsed state for project tree nodes (not persisted)
 const collapsedProjects = new Set()
 
@@ -145,11 +218,10 @@ function renderProjectTree(container, projects, parentId, depth) {
         deleteBtn.addEventListener('click', async (e) => {
             e.stopPropagation()
             const descendantCount = getDescendantIds(project.id).length
-            const msg = descendantCount > 0
-                ? `Delete "${project.name}" and its ${descendantCount} subproject(s)? Todos in these projects will become projectless.`
-                : `Delete "${project.name}"? Todos in this project will become projectless.`
-            if (confirm(msg)) {
-                await deleteProject(project.id)
+            const todoCount = getAllProjectTodoCount(project.id)
+            const { confirmed, deleteTodos } = await showDeleteProjectDialog(project.name, todoCount, descendantCount)
+            if (confirmed) {
+                await deleteProject(project.id, { deleteTodos })
             }
         })
 
@@ -207,11 +279,10 @@ function showProjectContextMenu(event, project, depth, projectContainer) {
     deleteItem.innerHTML = `${getIcon('x', { size: 14 })} Delete project`
     deleteItem.addEventListener('click', async () => {
         menu.remove()
-        const msg = descendantCount > 0
-            ? `Delete "${project.name}" and its ${descendantCount} subproject(s)? Todos in these projects will become projectless.`
-            : `Delete "${project.name}"? Todos in this project will become projectless.`
-        if (confirm(msg)) {
-            await deleteProject(project.id)
+        const todoCount = getAllProjectTodoCount(project.id)
+        const { confirmed, deleteTodos } = await showDeleteProjectDialog(project.name, todoCount, descendantCount)
+        if (confirmed) {
+            await deleteProject(project.id, { deleteTodos })
         }
     })
     menu.appendChild(deleteItem)
@@ -433,11 +504,10 @@ function renderManageProjectsTree(container, projects, areas, parentId, depth) {
         li.querySelector('.manage-projects-delete').addEventListener('click', async (e) => {
             e.stopPropagation()
             const descendantCount = getDescendantIds(project.id).length
-            const msg = descendantCount > 0
-                ? `Delete "${project.name}" and its ${descendantCount} subproject(s)? Todos in these projects will become projectless.`
-                : `Delete "${project.name}"? Todos in this project will become projectless.`
-            if (confirm(msg)) {
-                await deleteProject(project.id)
+            const todoCount = getAllProjectTodoCount(project.id)
+            const { confirmed, deleteTodos } = await showDeleteProjectDialog(project.name, todoCount, descendantCount)
+            if (confirmed) {
+                await deleteProject(project.id, { deleteTodos })
                 renderManageProjectsList(container)
             }
         })

--- a/styles.css
+++ b/styles.css
@@ -738,6 +738,104 @@ body.sidebar-resizing * {
     background: rgba(231, 76, 60, 0.1);
 }
 
+/* Delete project dialog */
+.delete-project-dialog-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    backdrop-filter: blur(2px);
+}
+
+.delete-project-dialog {
+    background: var(--bg-primary, #fff);
+    border-radius: 12px;
+    padding: 24px;
+    max-width: 400px;
+    width: 90%;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.delete-project-dialog-title {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--text-primary, #333);
+}
+
+.delete-project-dialog-text {
+    font-size: 14px;
+    color: var(--text-secondary, #666);
+    margin: 0 0 16px;
+    line-height: 1.4;
+}
+
+.delete-project-dialog-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.delete-project-dialog-btn {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    border: 1px solid var(--border-color, #e0e0e0);
+    border-radius: 8px;
+    background: var(--bg-secondary, #f8f8f8);
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary, #333);
+    text-align: left;
+    transition: background 0.15s, border-color 0.15s;
+    flex-wrap: wrap;
+}
+
+.delete-project-dialog-btn:hover {
+    background: var(--bg-hover, #f0f0f0);
+    border-color: var(--border-hover, #ccc);
+}
+
+.delete-project-dialog-btn-desc {
+    width: 100%;
+    font-size: 12px;
+    font-weight: 400;
+    color: var(--text-secondary, #888);
+    margin-left: 26px;
+}
+
+.delete-project-dialog-btn-delete {
+    color: #e74c3c;
+}
+
+.delete-project-dialog-btn-delete:hover {
+    background: rgba(231, 76, 60, 0.08);
+    border-color: rgba(231, 76, 60, 0.3);
+}
+
+.delete-project-dialog-cancel {
+    display: block;
+    width: 100%;
+    padding: 8px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--text-secondary, #888);
+    transition: background 0.15s;
+}
+
+.delete-project-dialog-cancel:hover {
+    background: var(--bg-hover, #f0f0f0);
+}
+
 .add-project-form {
     margin-top: 15px;
     padding-top: 15px;


### PR DESCRIPTION
## Summary
- When deleting a project that has tasks, show a dialog with two options:
  1. **Remove from project** — tasks become projectless (existing behavior)
  2. **Delete tasks** — tasks are permanently deleted along with the project
- Projects with no tasks still use a simple confirmation dialog
- Updated all 3 deletion entry points (sidebar button, context menu, manage modal)

## Test plan
- [ ] Delete a project that has tasks — verify dialog appears with both options
- [ ] Choose "Remove from project" — verify tasks become projectless
- [ ] Choose "Delete tasks" — verify tasks are deleted with the project
- [ ] Delete a project with no tasks — verify simple confirm dialog appears
- [ ] Press Escape or Cancel — verify dialog closes without action
- [ ] Delete a project with subprojects that have tasks — verify count includes descendant tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)