### PR TITLE
Simplify deploy workflow to prevent missed deployments

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,31 +2,15 @@ name: Deploy to GitHub Pages
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Auto Version Bump"]
-    types: [completed]
-    branches: [main]
   push:
     branches: [main]
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:
-    # Deploy when:
-    # - Manual trigger (workflow_dispatch), OR
-    # - Version bump workflow succeeded, OR
-    # - Version bump PR merged to main, OR
-    # - Direct push to main (not a PR merge that triggers version bump)
-    if: |
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      (github.event_name == 'push' &&
-       (startsWith(github.event.head_commit.message, 'chore: Bump version') ||
-        (!contains(github.event.head_commit.message, 'Merge pull request') &&
-         !contains(github.event.head_commit.message, '(#'))))
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
## Summary
- Removed complex `if` condition and `workflow_run` trigger from deploy workflow
- Now deploys on **every push to main** — no more missed deployments when version bump fails
- Changed `cancel-in-progress` to `true` so version bump commits supersede in-flight deploys

## What was broken
When the auto version bump workflow failed (e.g. stale branch conflict), the deploy was skipped because:
1. The `workflow_run` trigger only fired on `success`
2. The `push` trigger skipped PR merges (containing `(#`)

## How this fixes it
Every push to main triggers a deploy. If a PR merge push starts deploying and the version bump then pushes a new commit, `cancel-in-progress: true` cancels the stale deploy and starts a fresh one with the updated version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)