### PR TITLE
Add move-to-project option when deleting a project with tasks

### DIFF
--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -172,10 +172,33 @@ export async function addProject(name, parentId = null) {
  * @param {string} projectId - Project ID
  * @param {Object} [options] - Delete options
  * @param {boolean} [options.deleteTodos=false] - Also delete todos in these projects
+ * @param {string|null} [options.moveToProjectId=null] - Move non-closed todos to this project before deleting
  */
-export async function deleteProject(projectId, { deleteTodos = false } = {}) {
+export async function deleteProject(projectId, { deleteTodos = false, moveToProjectId = null } = {}) {
     const descendantIds = getDescendantIds(projectId)
     const removedIds = new Set([projectId, ...descendantIds])
+
+    // Move non-closed todos to another project if requested
+    if (moveToProjectId) {
+        const { error: moveError } = await supabase
+            .from('todos')
+            .update({ project_id: moveToProjectId })
+            .in('project_id', [...removedIds])
+            .neq('gtd_status', 'done')
+
+        if (moveError) {
+            console.error('Error moving project todos:', moveError)
+            throw moveError
+        }
+
+        const todos = store.get('todos').map(t => {
+            if (removedIds.has(t.project_id) && t.gtd_status !== 'done') {
+                return { ...t, project_id: moveToProjectId }
+            }
+            return t
+        })
+        store.set('todos', todos)
+    }
 
     // Delete todos in these projects if requested
     if (deleteTodos) {

--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -14,17 +14,44 @@ function getAllProjectTodoCount(projectId) {
 }
 
 /**
- * Show a delete project dialog with options when project has todos.
- * Returns a promise that resolves to { confirmed, deleteTodos }.
+ * Count non-closed todos in a project and its descendants
  */
-function showDeleteProjectDialog(projectName, todoCount, descendantCount) {
+function getNonClosedProjectTodoCount(projectId) {
+    const todos = store.get('todos')
+    const ids = new Set([projectId, ...getDescendantIds(projectId)])
+    return todos.filter(t => ids.has(t.project_id) && t.gtd_status !== 'done').length
+}
+
+/**
+ * Build project select options excluding a project and its descendants
+ */
+function buildProjectOptions(excludeProjectId) {
+    const projects = store.get('projects')
+    const excludeIds = new Set([excludeProjectId, ...getDescendantIds(excludeProjectId)])
+    const available = projects.filter(p => !excludeIds.has(p.id))
+
+    if (available.length === 0) return ''
+
+    return available
+        .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+        .map(p => `<option value="${p.id}">${escapeHtml(p.name)}</option>`)
+        .join('')
+}
+
+/**
+ * Show a delete project dialog with options when project has todos.
+ * Returns a promise that resolves to { confirmed, deleteTodos, moveToProjectId }.
+ */
+function showDeleteProjectDialog(projectName, todoCount, descendantCount, projectId) {
     return new Promise(resolve => {
+        const noResult = { confirmed: false, deleteTodos: false, moveToProjectId: null }
+
         // No todos — use simple confirm
         if (todoCount === 0) {
             const msg = descendantCount > 0
                 ? `Delete "${projectName}" and its ${descendantCount} subproject(s)?`
                 : `Delete "${projectName}"?`
-            resolve({ confirmed: confirm(msg), deleteTodos: false })
+            resolve({ confirmed: confirm(msg), deleteTodos: false, moveToProjectId: null })
             return
         }
 
@@ -34,6 +61,10 @@ function showDeleteProjectDialog(projectName, todoCount, descendantCount) {
         const projectLabel = descendantCount > 0
             ? `"${escapeHtml(projectName)}" and its ${descendantCount} subproject(s)`
             : `"${escapeHtml(projectName)}"`
+
+        const nonClosedCount = getNonClosedProjectTodoCount(projectId)
+        const projectOptions = buildProjectOptions(projectId)
+        const showMoveOption = nonClosedCount > 0 && projectOptions
 
         overlay.innerHTML = `
             <div class="delete-project-dialog" role="dialog" aria-modal="true" aria-label="Delete project">
@@ -45,6 +76,19 @@ function showDeleteProjectDialog(projectName, todoCount, descendantCount) {
                         Remove from project
                         <span class="delete-project-dialog-btn-desc">Tasks will become projectless</span>
                     </button>
+                    ${showMoveOption ? `
+                    <div class="delete-project-dialog-btn delete-project-dialog-btn-move">
+                        ${getIcon('folder', { size: 16 })}
+                        Move to another project
+                        <span class="delete-project-dialog-btn-desc">${nonClosedCount} non-closed task${nonClosedCount !== 1 ? 's' : ''} will be moved</span>
+                        <div class="delete-project-dialog-move-select">
+                            <select class="delete-project-dialog-select" aria-label="Target project">
+                                ${projectOptions}
+                            </select>
+                            <button class="delete-project-dialog-move-confirm" data-action="move-confirm">Move & Delete</button>
+                        </div>
+                    </div>
+                    ` : ''}
                     <button class="delete-project-dialog-btn delete-project-dialog-btn-delete" data-action="delete">
                         ${getIcon('trash', { size: 16 })}
                         Delete tasks
@@ -62,15 +106,19 @@ function showDeleteProjectDialog(projectName, todoCount, descendantCount) {
         }
 
         const onKey = (e) => {
-            if (e.key === 'Escape') cleanup({ confirmed: false, deleteTodos: false })
+            if (e.key === 'Escape') cleanup(noResult)
         }
         document.addEventListener('keydown', onKey)
 
         overlay.addEventListener('click', (e) => {
             const action = e.target.closest('[data-action]')?.dataset.action
-            if (action === 'keep') cleanup({ confirmed: true, deleteTodos: false })
-            else if (action === 'delete') cleanup({ confirmed: true, deleteTodos: true })
-            else if (action === 'cancel' || e.target === overlay) cleanup({ confirmed: false, deleteTodos: false })
+            if (action === 'keep') cleanup({ confirmed: true, deleteTodos: false, moveToProjectId: null })
+            else if (action === 'move-confirm') {
+                const select = overlay.querySelector('.delete-project-dialog-select')
+                cleanup({ confirmed: true, deleteTodos: false, moveToProjectId: select.value })
+            }
+            else if (action === 'delete') cleanup({ confirmed: true, deleteTodos: true, moveToProjectId: null })
+            else if (action === 'cancel' || e.target === overlay) cleanup(noResult)
         })
 
         document.body.appendChild(overlay)
@@ -219,9 +267,9 @@ function renderProjectTree(container, projects, parentId, depth) {
             e.stopPropagation()
             const descendantCount = getDescendantIds(project.id).length
             const todoCount = getAllProjectTodoCount(project.id)
-            const { confirmed, deleteTodos } = await showDeleteProjectDialog(project.name, todoCount, descendantCount)
+            const { confirmed, deleteTodos, moveToProjectId } = await showDeleteProjectDialog(project.name, todoCount, descendantCount, project.id)
             if (confirmed) {
-                await deleteProject(project.id, { deleteTodos })
+                await deleteProject(project.id, { deleteTodos, moveToProjectId })
             }
         })
 
@@ -280,9 +328,9 @@ function showProjectContextMenu(event, project, depth, projectContainer) {
     deleteItem.addEventListener('click', async () => {
         menu.remove()
         const todoCount = getAllProjectTodoCount(project.id)
-        const { confirmed, deleteTodos } = await showDeleteProjectDialog(project.name, todoCount, descendantCount)
+        const { confirmed, deleteTodos, moveToProjectId } = await showDeleteProjectDialog(project.name, todoCount, descendantCount, project.id)
         if (confirmed) {
-            await deleteProject(project.id, { deleteTodos })
+            await deleteProject(project.id, { deleteTodos, moveToProjectId })
         }
     })
     menu.appendChild(deleteItem)
@@ -505,9 +553,9 @@ function renderManageProjectsTree(container, projects, areas, parentId, depth) {
             e.stopPropagation()
             const descendantCount = getDescendantIds(project.id).length
             const todoCount = getAllProjectTodoCount(project.id)
-            const { confirmed, deleteTodos } = await showDeleteProjectDialog(project.name, todoCount, descendantCount)
+            const { confirmed, deleteTodos, moveToProjectId } = await showDeleteProjectDialog(project.name, todoCount, descendantCount, project.id)
             if (confirmed) {
-                await deleteProject(project.id, { deleteTodos })
+                await deleteProject(project.id, { deleteTodos, moveToProjectId })
                 renderManageProjectsList(container)
             }
         })

--- a/styles.css
+++ b/styles.css
@@ -836,6 +836,46 @@ body.sidebar-resizing * {
     background: var(--bg-hover, #f0f0f0);
 }
 
+.delete-project-dialog-btn-move {
+    cursor: default;
+}
+
+.delete-project-dialog-move-select {
+    display: flex;
+    gap: 8px;
+    width: 100%;
+    margin-left: 26px;
+    margin-top: 4px;
+}
+
+.delete-project-dialog-select {
+    flex: 1;
+    padding: 6px 8px;
+    border: 1px solid var(--border-color, #e0e0e0);
+    border-radius: 6px;
+    background: var(--bg-primary, #fff);
+    color: var(--text-primary, #333);
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.delete-project-dialog-move-confirm {
+    padding: 6px 12px;
+    border: none;
+    border-radius: 6px;
+    background: var(--accent-color, #4a90d9);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s;
+}
+
+.delete-project-dialog-move-confirm:hover {
+    background: var(--accent-hover, #3a7bc8);
+}
+
 .add-project-form {
     margin-top: 15px;
     padding-top: 15px;


### PR DESCRIPTION
## Summary
- When deleting a project that has non-closed tasks, the delete dialog now offers a third option: **Move to another project**
- A dropdown lets the user select the target project (excludes the project being deleted and its descendants)
- Only non-closed tasks (not "done") are moved; closed tasks remain and are handled by the existing keep/delete options
- All 3 deletion entry points updated (sidebar button, context menu, manage modal)

## Changes
- `src/services/projects.js` — Added `moveToProjectId` option to `deleteProject()`, bulk-updates non-closed todos via Supabase
- `src/ui/ProjectList.js` — Added project selector to delete dialog, helper functions for counting non-closed todos and building project options
- `styles.css` — Styled the move-to-project select and confirm button

## Test plan
- [ ] Delete a project with non-closed tasks — verify "Move to another project" option appears
- [ ] Select a target project and click "Move & Delete" — verify tasks move and project is deleted
- [ ] Verify closed/done tasks are not moved
- [ ] Delete a project when no other projects exist — verify move option is hidden
- [ ] Delete a project with subprojects — verify descendant projects are excluded from dropdown
- [ ] Verify "Remove from project" and "Delete tasks" options still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)