### PR TITLE
Add drag-and-drop reordering to sidebar project tree

### DIFF
--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -140,6 +140,7 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.project-color/,
     /\.project-count/,
     /\.project-delete/,
+    /\.project-drag-handle/,
     /\.project-card/,
     // Context items (rendered by JavaScript)
     /\.context-item/,

--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -190,7 +190,9 @@ function renderProjectTree(container, projects, parentId, depth) {
         li.className = `project-item ${state.selectedProjectId === project.id ? 'active' : ''}`
         li.style.paddingLeft = `${12 + depth * 20}px`
         li.dataset.projectId = project.id
+        li.dataset.parentId = parentId || ''
         li.dataset.depth = depth
+        li.draggable = true
 
         const count = getProjectTodoCount(project.id)
         const countDisplay = count > 0 ? count : ''
@@ -206,14 +208,21 @@ function renderProjectTree(container, projects, parentId, depth) {
             expandHtml = '<span class="project-expand-spacer"></span>'
         }
 
+        // Build the project item content using safe helpers (escapeHtml, validateColor)
+        const dragHandleHtml = getIcon('drag-handle', { size: 12 })
+        const colorStyle = validateColor(project.color)
+        const safeName = escapeHtml(project.name)
+        const deleteIconHtml = getIcon('x', { size: 12 })
+
         li.innerHTML = `
+            <span class="project-drag-handle">${dragHandleHtml}</span>
             ${expandHtml}
             <span class="project-name">
-                <span class="project-color" style="background-color: ${validateColor(project.color)}"></span>
-                ${escapeHtml(project.name)}
+                <span class="project-color" style="background-color: ${colorStyle}"></span>
+                ${safeName}
             </span>
             <span class="project-count">${countDisplay}</span>
-            <button class="project-delete" data-id="${project.id}">${getIcon('x', { size: 12 })}</button>
+            <button class="project-delete" data-id="${project.id}">${deleteIconHtml}</button>
         `
 
         // Expand/collapse toggle
@@ -230,9 +239,27 @@ function renderProjectTree(container, projects, parentId, depth) {
             })
         }
 
+        // Project drag-and-drop for reordering
+        li.addEventListener('dragstart', (e) => {
+            if (!e.target.closest('.project-drag-handle')) {
+                e.preventDefault()
+                return
+            }
+            e.dataTransfer.setData('application/x-project-id', project.id)
+            e.dataTransfer.setData('application/x-project-parent-id', parentId || '')
+            e.dataTransfer.effectAllowed = 'move'
+            li.classList.add('dragging')
+        })
+        li.addEventListener('dragend', () => {
+            li.classList.remove('dragging')
+            container.querySelectorAll('.project-item').forEach(item => {
+                item.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom')
+            })
+        })
+
         // Click to select project
         li.addEventListener('click', (e) => {
-            if (!e.target.closest('.project-delete') && !e.target.closest('.project-expand')) {
+            if (!e.target.closest('.project-delete') && !e.target.closest('.project-expand') && !e.target.closest('.project-drag-handle')) {
                 selectProject(project.id)
             }
         })
@@ -243,21 +270,58 @@ function renderProjectTree(container, projects, parentId, depth) {
             showProjectContextMenu(e, project, depth, container)
         })
 
-        // Drop target for assigning project
+        // Drop target for both todo assignment and project reordering
         li.addEventListener('dragover', (e) => {
             e.preventDefault()
-            e.dataTransfer.dropEffect = 'move'
-            li.classList.add('drag-over')
+            const isProjectDrag = e.dataTransfer.types.includes('application/x-project-id')
+            if (isProjectDrag) {
+                const dragging = container.querySelector('.project-item.dragging')
+                if (dragging && dragging !== li && dragging.dataset.parentId === li.dataset.parentId) {
+                    e.dataTransfer.dropEffect = 'move'
+                    const rect = li.getBoundingClientRect()
+                    const midY = rect.top + rect.height / 2
+                    li.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom')
+                    if (e.clientY < midY) {
+                        li.classList.add('drag-over-top')
+                    } else {
+                        li.classList.add('drag-over-bottom')
+                    }
+                }
+            } else {
+                e.dataTransfer.dropEffect = 'move'
+                li.classList.add('drag-over')
+            }
         })
         li.addEventListener('dragleave', () => {
-            li.classList.remove('drag-over')
+            li.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom')
         })
-        li.addEventListener('drop', (e) => {
+        li.addEventListener('drop', async (e) => {
             e.preventDefault()
-            li.classList.remove('drag-over')
-            const todoId = e.dataTransfer.getData('text/plain')
-            if (todoId) {
-                updateTodoProject(todoId, project.id)
+            li.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom')
+
+            const projectDragId = e.dataTransfer.getData('application/x-project-id')
+            if (projectDragId) {
+                // Project reorder drop
+                const dragging = container.querySelector('.project-item.dragging')
+                if (dragging && dragging !== li && dragging.dataset.parentId === li.dataset.parentId) {
+                    const rect = li.getBoundingClientRect()
+                    const midY = rect.top + rect.height / 2
+                    if (e.clientY < midY) {
+                        li.before(dragging)
+                    } else {
+                        li.after(dragging)
+                    }
+                    const siblingParentId = dragging.dataset.parentId
+                    const orderedIds = [...container.querySelectorAll(`.project-item[data-parent-id="${siblingParentId}"]`)]
+                        .map(item => item.dataset.projectId)
+                    await reorderProjects(orderedIds)
+                }
+            } else {
+                // Todo assignment drop
+                const todoId = e.dataTransfer.getData('text/plain')
+                if (todoId) {
+                    updateTodoProject(todoId, project.id)
+                }
             }
         })
 

--- a/styles.css
+++ b/styles.css
@@ -697,6 +697,51 @@ body.sidebar-resizing * {
     color: rgba(255, 255, 255, 0.8);
 }
 
+/* Project sidebar drag handle */
+.project-drag-handle {
+    opacity: 0;
+    cursor: grab;
+    color: #999;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 2px;
+    transition: opacity 0.2s;
+}
+
+.project-drag-handle svg {
+    width: 12px;
+    height: 12px;
+}
+
+.project-item:hover .project-drag-handle {
+    opacity: 0.5;
+}
+
+.project-drag-handle:hover {
+    opacity: 1 !important;
+}
+
+.project-drag-handle:active {
+    cursor: grabbing;
+}
+
+.project-item.dragging {
+    opacity: 0.5;
+    cursor: grabbing;
+}
+
+.project-item.drag-over-top {
+    border-top: 2px solid var(--accent-color, #007AFF);
+    margin-top: -2px;
+}
+
+.project-item.drag-over-bottom {
+    border-bottom: 2px solid var(--accent-color, #007AFF);
+    margin-bottom: -2px;
+}
+
 /* Project context menu */
 .project-context-menu {
     position: fixed;
@@ -3849,6 +3894,10 @@ body.sidebar-resizing * {
         display: none;
     }
 
+    .project-drag-handle {
+        display: none;
+    }
+
     .manage-projects-color {
         grid-column: 1;
         grid-row: 1;
@@ -5938,6 +5987,24 @@ body.sidebar-resizing * {
     color: white !important;
     transform: scale(1.02);
     box-shadow: 0 2px 8px rgba(0, 122, 255, 0.3);
+}
+
+[data-theme="glass"] .project-drag-handle,
+[data-theme="dark"] .project-drag-handle,
+[data-theme="clear"] .project-drag-handle {
+    color: var(--ios-label-tertiary);
+}
+
+[data-theme="glass"] .project-item.drag-over-top,
+[data-theme="dark"] .project-item.drag-over-top,
+[data-theme="clear"] .project-item.drag-over-top {
+    border-top-color: var(--ios-blue);
+}
+
+[data-theme="glass"] .project-item.drag-over-bottom,
+[data-theme="dark"] .project-item.drag-over-bottom,
+[data-theme="clear"] .project-item.drag-over-bottom {
+    border-bottom-color: var(--ios-blue);
 }
 
 /* Glass/Dark/Clear GTD Tab Bar */


### PR DESCRIPTION
## Summary
- Add drag handle to each project in the sidebar tree for reordering via drag-and-drop
- Use custom MIME type (`application/x-project-id`) to distinguish project reorder drags from existing todo-to-project assignment drops
- Reordering is scoped to siblings (same parent), preserving the tree hierarchy
- Includes themed styles (glass/dark/clear) and hides drag handle on mobile

## Test plan
- [ ] Hover over a project in the sidebar — drag handle (dots icon) appears on the left
- [ ] Drag a project by its handle to reorder among siblings — blue border indicator shows drop position
- [ ] Drop above or below a sibling project — order updates and persists after refresh
- [ ] Drag a todo onto a project — still assigns the todo to that project (existing behavior preserved)
- [ ] Verify reordering works correctly with subprojects (children reorder within their parent group)
- [ ] Test on glass, dark, and clear themes — drag handle and indicators use theme colors
- [ ] On mobile viewport — drag handle is hidden (touch drag not supported)
- [ ] Run `npm run check:css` — passes with no broken selectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)