### PR TITLE
Fix project drag-and-drop not working in Safari

### DIFF
--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -196,7 +196,6 @@ function renderProjectTree(container, projects, parentId, depth) {
         li.dataset.projectId = project.id
         li.dataset.parentId = parentId || ''
         li.dataset.depth = depth
-        li.draggable = true
 
         const count = getProjectTodoCount(project.id)
         const countDisplay = count > 0 ? count : ''
@@ -244,17 +243,22 @@ function renderProjectTree(container, projects, parentId, depth) {
         }
 
         // Project drag-and-drop for reordering
+        // Enable draggable only when mousedown on the drag handle (Safari compatible)
+        const dragHandle = li.querySelector('.project-drag-handle')
+        dragHandle.addEventListener('mousedown', () => {
+            li.draggable = true
+        })
+        dragHandle.addEventListener('mouseup', () => {
+            li.draggable = false
+        })
         li.addEventListener('dragstart', (e) => {
-            if (!e.target.closest('.project-drag-handle')) {
-                e.preventDefault()
-                return
-            }
             e.dataTransfer.setData('text/plain', project.id)
             e.dataTransfer.effectAllowed = 'move'
             activeProjectDrag = { id: project.id, parentId: parentId || '' }
             li.classList.add('dragging')
         })
         li.addEventListener('dragend', () => {
+            li.draggable = false
             activeProjectDrag = null
             li.classList.remove('dragging')
             container.querySelectorAll('.project-item').forEach(item => {


### PR DESCRIPTION
## Summary
- Safari sets `e.target` in `dragstart` to the draggable element (`li`), not the child element the user clicked on
- The `e.target.closest('.project-drag-handle')` check searched *upward* from `li` and never found the handle (which is a *child*), so the drag was always cancelled
- Fix: toggle `li.draggable` via `mousedown`/`mouseup` on the drag handle instead — the same cross-browser pattern used in the manage-projects modal
- `li` starts with `draggable=false`, becomes draggable only while the handle is held, and resets on `dragend`

## Test plan
- [ ] **Safari**: grab a project by the drag handle — drag initiates, indicators show, drop reorders
- [ ] **Chrome/Firefox**: verify drag-and-drop still works correctly
- [ ] Clicking a project (not on handle) still selects it
- [ ] Dragging a todo onto a project still assigns it

🤖 Generated with [Claude Code](https://claude.com/claude-code)