### PR TITLE
Fix project drop not registering in Safari

### DIFF
--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -259,11 +259,13 @@ function renderProjectTree(container, projects, parentId, depth) {
         })
         li.addEventListener('dragend', () => {
             li.draggable = false
-            activeProjectDrag = null
             li.classList.remove('dragging')
             container.querySelectorAll('.project-item').forEach(item => {
                 item.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom')
             })
+            // Clear activeProjectDrag after a tick so drop handler processes first
+            // (Safari can fire dragend before drop on the target)
+            setTimeout(() => { activeProjectDrag = null }, 0)
         })
 
         // Click to select project
@@ -281,9 +283,10 @@ function renderProjectTree(container, projects, parentId, depth) {
 
         // Drop target for both todo assignment and project reordering
         li.addEventListener('dragover', (e) => {
-            e.preventDefault()
             if (activeProjectDrag) {
+                // Only accept drops from siblings
                 if (activeProjectDrag.parentId === (li.dataset.parentId || '') && activeProjectDrag.id !== project.id) {
+                    e.preventDefault()
                     e.dataTransfer.dropEffect = 'move'
                     const rect = li.getBoundingClientRect()
                     const midY = rect.top + rect.height / 2
@@ -295,6 +298,8 @@ function renderProjectTree(container, projects, parentId, depth) {
                     }
                 }
             } else {
+                // Todo assignment drop
+                e.preventDefault()
                 e.dataTransfer.dropEffect = 'move'
                 li.classList.add('drag-over')
             }


### PR DESCRIPTION
## Summary
- **Event ordering fix**: Safari can fire `dragend` on the source before `drop` on the target, which cleared `activeProjectDrag` before the drop handler could read it. Fixed by deferring the clear with `setTimeout(_, 0)`.
- **Drop validation fix**: `e.preventDefault()` was called unconditionally in `dragover`, but `dropEffect` was only set conditionally. Safari requires consistent `effectAllowed`/`dropEffect` pairing — without it, it rejects the drop. Fixed by only calling `preventDefault()` on valid sibling drop targets.

## Test plan
- [ ] **Safari**: drag a project by its handle over a sibling — blue indicator line appears
- [ ] **Safari**: drop the project — it reorders and persists after refresh
- [ ] **Safari**: drag a project over a non-sibling — no drop indicator, drop rejected
- [ ] **Chrome/Firefox**: verify drag-and-drop reordering still works
- [ ] Drag a todo onto a project — still assigns the todo correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)