### PR TITLE
Allow reparenting between sibling projects via three-zone drop

### DIFF
--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -294,6 +294,7 @@ function renderProjectTree(container, projects, parentId, depth) {
         })
 
         // Drop target for todo assignment, project reordering, and reparenting
+        // Three-zone drop: top 25% = reorder above, middle 50% = reparent, bottom 25% = reorder below
         li.addEventListener('dragover', (e) => {
             if (activeProjectDrag) {
                 if (activeProjectDrag.id === project.id) return
@@ -303,19 +304,15 @@ function renderProjectTree(container, projects, parentId, depth) {
 
                 e.preventDefault()
                 e.dataTransfer.dropEffect = 'move'
-                const isSibling = activeProjectDrag.parentId === (li.dataset.parentId || '')
+                const rect = li.getBoundingClientRect()
+                const relY = e.clientY - rect.top
+                const quarter = rect.height * 0.25
                 li.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom')
-                if (isSibling) {
-                    // Sibling reorder — show position indicator
-                    const rect = li.getBoundingClientRect()
-                    const midY = rect.top + rect.height / 2
-                    if (e.clientY < midY) {
-                        li.classList.add('drag-over-top')
-                    } else {
-                        li.classList.add('drag-over-bottom')
-                    }
+                if (relY < quarter) {
+                    li.classList.add('drag-over-top')
+                } else if (relY > rect.height - quarter) {
+                    li.classList.add('drag-over-bottom')
                 } else {
-                    // Reparent — highlight as new parent
                     li.classList.add('drag-over')
                 }
             } else {
@@ -334,14 +331,16 @@ function renderProjectTree(container, projects, parentId, depth) {
 
             if (activeProjectDrag) {
                 if (activeProjectDrag.id === project.id) return
-                const isSibling = activeProjectDrag.parentId === (li.dataset.parentId || '')
-                if (isSibling) {
-                    // Sibling reorder
+                const rect = li.getBoundingClientRect()
+                const relY = e.clientY - rect.top
+                const quarter = rect.height * 0.25
+                const isReorder = relY < quarter || relY > rect.height - quarter
+
+                if (isReorder && activeProjectDrag.parentId === (li.dataset.parentId || '')) {
+                    // Sibling reorder (edge zones, same parent only)
                     const dragging = container.querySelector('.project-item.dragging')
                     if (dragging && dragging !== li) {
-                        const rect = li.getBoundingClientRect()
-                        const midY = rect.top + rect.height / 2
-                        if (e.clientY < midY) {
+                        if (relY < quarter) {
                             li.before(dragging)
                         } else {
                             li.after(dragging)


### PR DESCRIPTION
## Summary
Previously, dragging a project onto a sibling always triggered reorder because the code checked `isSibling` first. Now each drop target uses a **three-zone** layout:

- **Top 25%** → reorder above (border-top indicator, siblings only)
- **Middle 50%** → reparent as child (full highlight)
- **Bottom 25%** → reorder below (border-bottom indicator, siblings only)

This allows dropping `SubProject1` onto the middle of `SubProject2` to make it a child, even when they share the same parent.

Edge-zone drops on non-siblings fall through to reparent as well (since cross-parent reordering isn't meaningful).

## Test plan
- [ ] Drag SubProject1 to the **middle** of sibling SubProject2 → reparents as child
- [ ] Drag SubProject1 to the **top edge** of sibling SubProject2 → reorders above
- [ ] Drag SubProject1 to the **bottom edge** of sibling SubProject2 → reorders below
- [ ] Drag a project onto a non-sibling (any zone) → reparents
- [ ] Drag onto "All Projects" → moves to root
- [ ] Depth limit (3 levels) still enforced with alert
- [ ] Todo-to-project drag still works
- [ ] Test in Safari and Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)