### PR TITLE
Add Delete All button to Done view

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ import {
     loadUserSettings, saveUserSettings,
     loadNotificationSettings, saveNotificationSettings
 } from './src/services/settings.js'
-import { loadTodos, addTodo, toggleTodo, deleteTodo, getGtdCount, clearTodoSelection } from './src/services/todos.js'
+import { loadTodos, addTodo, toggleTodo, deleteTodo, getGtdCount, clearTodoSelection, bulkDeleteTodos } from './src/services/todos.js'
 import { performUndo, clearUndoStack } from './src/services/undo.js'
 import { loadProjects, addProject, deleteProject, selectProject } from './src/services/projects.js'
 import { loadAreas, addArea, selectArea, selectAreaByShortcut, restoreSelectedArea } from './src/services/areas.js'
@@ -81,6 +81,7 @@ class TodoApp {
         this.projectsSection = document.getElementById('projectsSection')
         this.gtdTabBar = document.getElementById('gtdTabBar')
         this.gtdStatusHeader = document.getElementById('gtdStatusHeader')
+        this.deleteAllDoneBtn = document.getElementById('deleteAllDoneBtn')
         this.exportBtn = document.getElementById('exportBtn')
         this.searchInput = document.getElementById('searchInput')
         this.versionNumberEl = document.getElementById('versionNumber')
@@ -438,6 +439,14 @@ class TodoApp {
 
         // Density selector
         this.densitySelect.addEventListener('change', () => changeDensity(this.densitySelect.value))
+
+        // Delete all done button
+        this.deleteAllDoneBtn.addEventListener('click', async () => {
+            const doneTodos = store.get('todos').filter(t => t.gtd_status === 'done')
+            if (doneTodos.length === 0) return
+            if (!confirm(`Delete all ${doneTodos.length} done task${doneTodos.length !== 1 ? 's' : ''}?`)) return
+            await bulkDeleteTodos(doneTodos.map(t => t.id))
+        })
 
         // Export button
         this.exportBtn.addEventListener('click', () => this.exportModal.open())

--- a/index.html
+++ b/index.html
@@ -225,6 +225,7 @@
                     <div id="gtdStatusHeader" class="gtd-status-header">
                         <span class="gtd-status-header-icon"></span>
                         <span class="gtd-status-header-name"></span>
+                        <button id="deleteAllDoneBtn" class="delete-all-done-btn" style="display: none;" title="Delete all done tasks">Delete All</button>
                     </div>
 
                     <div id="areaHeader" class="area-header" style="display: none;">

--- a/src/ui/GtdList.js
+++ b/src/ui/GtdList.js
@@ -161,8 +161,16 @@ export function updateGtdStatusHeader(headerElement) {
 
     const iconSpan = headerElement.querySelector('.gtd-status-header-icon')
     const nameSpan = headerElement.querySelector('.gtd-status-header-name')
+    const deleteAllBtn = headerElement.querySelector('.delete-all-done-btn')
 
+    // Safe: getIcon returns trusted SVG markup, not user content
     iconSpan.innerHTML = getIcon(status, { size: 20 })
     nameSpan.textContent = statusInfo.label
     headerElement.className = `gtd-status-header ${status}`
+
+    // Show "Delete All" button only on Done view with items
+    if (deleteAllBtn) {
+        const doneCount = store.state.todos.filter(t => t.gtd_status === 'done').length
+        deleteAllBtn.style.display = status === 'done' && doneCount > 0 ? '' : 'none'
+    }
 }

--- a/styles.css
+++ b/styles.css
@@ -1034,6 +1034,24 @@ body.sidebar-resizing * {
     font-size: 15px;
     font-weight: 600;
     color: var(--ios-label, #333);
+    flex: 1;
+}
+
+.delete-all-done-btn {
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    background: rgba(255, 59, 48, 0.1);
+    color: #ff3b30;
+    transition: background 0.2s;
+    flex-shrink: 0;
+}
+
+.delete-all-done-btn:hover {
+    background: rgba(255, 59, 48, 0.2);
 }
 
 /* Per-status icon colors */
@@ -4767,6 +4785,19 @@ body.sidebar-resizing * {
 [data-theme="dark"] .gtd-status-header-name,
 [data-theme="clear"] .gtd-status-header-name {
     color: var(--ios-label);
+}
+
+[data-theme="glass"] .delete-all-done-btn,
+[data-theme="dark"] .delete-all-done-btn,
+[data-theme="clear"] .delete-all-done-btn {
+    background: rgba(255, 59, 48, 0.15);
+    color: var(--ios-red, #ff3b30);
+}
+
+[data-theme="glass"] .delete-all-done-btn:hover,
+[data-theme="dark"] .delete-all-done-btn:hover,
+[data-theme="clear"] .delete-all-done-btn:hover {
+    background: rgba(255, 59, 48, 0.25);
 }
 
 [data-theme="glass"] .area-header,


### PR DESCRIPTION
## Summary
- Adds a "Delete All" button in the GTD status header, visible only when viewing the Done list
- Button styled in red (iOS destructive action style) with themed variants for glass/dark/clear
- Confirms with the user before deleting: "Delete all X done tasks?"
- Uses existing `bulkDeleteTodos()` which supports **undo** — accidentally deleted tasks can be recovered
- Button auto-hides when there are no done tasks

## Test plan
- [ ] Navigate to Done view — "Delete All" button appears in the header
- [ ] Navigate to any other GTD view (Inbox, Next, etc.) — button is hidden
- [ ] Click "Delete All" → confirmation dialog shows count of done tasks
- [ ] Confirm deletion → all done tasks are removed
- [ ] Press Ctrl+Z / undo → deleted tasks are restored
- [ ] Cancel confirmation → nothing happens
- [ ] When Done list is empty, button is hidden
- [ ] Test on glass, dark, and clear themes — button uses themed colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)