### PR TITLE
Disable area assignment for subprojects

### DIFF
--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -562,7 +562,7 @@ function renderManageProjectsTree(container, projects, areas, parentId, depth) {
                 <span class="manage-projects-name">${escapeHtml(project.name)}</span>
                 ${descriptionHtml}
             </div>
-            <select class="manage-projects-area" title="Assign to area">${areaOptions}</select>
+            <select class="manage-projects-area" title="Assign to area"${depth > 0 ? ' disabled' : ''}>${areaOptions}</select>
             <div class="manage-projects-actions">
                 <button class="manage-projects-edit" data-id="${project.id}" title="Edit">${getIcon('edit', { size: 14 })}</button>
                 <button class="manage-projects-delete" data-id="${project.id}" title="Delete">${getIcon('x', { size: 14 })}</button>


### PR DESCRIPTION
## Summary
- Subprojects now have their area dropdown disabled in the manage projects modal
- Area assignment is only available for top-level projects; subprojects inherit from their parent
- The backend already propagates area changes to all descendants (`updateProject` in `projects.js`), this change enforces the constraint in the UI

## Test plan
- [ ] Open Manage Projects modal — top-level projects should have an enabled area dropdown
- [ ] Subprojects should have a disabled (greyed out) area dropdown
- [ ] Changing a top-level project's area still propagates to all its subprojects
- [ ] Verify disabled dropdown is visually distinct across all themes (Glass, Dark, Clear)

🤖 Generated with [Claude Code](https://claude.ai/code)