### PR TITLE
Fix mobile sidebar consuming entire viewport on Safari

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -268,6 +268,7 @@ body.fullscreen-mode .container {
     border-radius: 0;
     box-shadow: none;
     height: 100vh;
+    height: 100dvh;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -3675,6 +3676,14 @@ body.sidebar-resizing * {
         width: 100%;
         min-width: unset;
         max-width: unset;
+        max-height: 40vh;
+        flex-shrink: 0;
+    }
+
+    body.fullscreen-mode .content {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
     }
 
     .sidebar-resize-handle {


### PR DESCRIPTION
## Summary
- Cap sidebar height at `max-height: 40vh` on mobile (≤768px) so the project list doesn't push the todo content off-screen when expanded
- Add `overflow-y: auto` to `.content` on mobile so the todo list scrolls properly within the remaining viewport space
- Use `100dvh` (dynamic viewport height) alongside `100vh` for the container height, fixing layout issues caused by Safari's collapsible address bar

## Problem
On mobile Safari (iPhone), when the project list is expanded, it fills the entire viewport and the user cannot scroll down to see their todos. When collapsed, the todos are confined to a small scrollable area instead of using the full remaining space.

## Test plan
- [ ] Open on iPhone Safari with projects expanded — project list should scroll within its capped area, todos visible below
- [ ] Open on iPhone Safari with projects collapsed — todos should use the full remaining viewport
- [ ] Verify scrolling works smoothly in both sections
- [ ] Test with Safari address bar visible and hidden (dvh handling)
- [ ] Verify no layout changes on desktop (≥768px)
- [ ] Test on Chrome mobile as well

🤖 Generated with [Claude Code](https://claude.ai/code)