### PR TITLE
Use PAT_TOKEN for version bump PR to trigger CI workflows

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create version bump PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           BRANCH="chore/version-bump-${{ steps.new_version.outputs.version }}"
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- Switch the auto-version-bump workflow from `GITHUB_TOKEN` to `PAT_TOKEN` when creating the version bump PR

## Problem
PRs created by `GITHUB_TOKEN` don't trigger other workflows (GitHub security design to prevent infinite loops). This means the E2E Tests workflow never runs on version bump PRs, blocking auto-merge since the required `test` check never reports a status.

We've had to manually close/reopen version bump PRs (#325, #338) to retrigger the tests each time.

## Solution
Use `PAT_TOKEN` (a fine-grained Personal Access Token) instead. PRs created with a PAT do trigger other workflows, so the E2E test will run automatically and auto-merge will proceed without intervention.

## Test plan
- [ ] Merge this PR and verify the next version bump PR gets its E2E test triggered automatically
- [ ] Verify auto-merge completes without manual intervention

🤖 Generated with [Claude Code](https://claude.ai/code)