### PR TITLE
Add E2E project tests (fixes #329)

### DIFF
--- a/tests/e2e/projects.spec.js
+++ b/tests/e2e/projects.spec.js
@@ -236,10 +236,11 @@ test.describe('Projects', () => {
         await expect(todoItem(authedPage, todoName)).toBeVisible({ timeout: 5000 })
         await expect(todoItem(authedPage, otherTodoName)).not.toBeAttached({ timeout: 5000 })
 
-        // Switch back to All Projects
-        await authedPage.locator('#projectList .project-item', { has: authedPage.locator('.project-name', { hasText: 'All Projects' }) }).click()
+        // Click a GTD tab to exit project view and return to todo list
+        // ("All Projects" shows a projects overview, not the todo list)
+        await authedPage.click('.gtd-tab.inbox')
 
-        // Both should be visible now
+        // Both should be visible now (no project filter, Inbox GTD)
         await expect(todoItem(authedPage, todoName)).toBeVisible({ timeout: 10000 })
         await expect(todoItem(authedPage, otherTodoName)).toBeVisible({ timeout: 10000 })
 


### PR DESCRIPTION
## Summary
- Adds comprehensive Playwright E2E tests for project management
- 10 test cases covering the full project lifecycle

## Test Cases
1. **Add project** via sidebar input
2. **Add project** via Manage Projects modal
3. **Rename project** via inline edit in Manage modal (edit button → input → Enter)
4. **Delete project** with no todos (window.confirm dialog)
5. **Delete project with todos** - "Remove from project" option (custom dialog)
6. **Delete project with todos** - "Delete tasks" option (custom dialog)
7. **Select project** to filter todos (only project's todos visible)
8. **Project todo count badge** accuracy (0 → empty, 1 → "1")
9. **Add subproject** via right-click context menu (prompt dialog)
10. **Undo project deletion** via toast button
11. **Area dropdown disabled** for subprojects in Manage modal

## Implementation Details
- Uses `authedPage` fixture from test infrastructure
- Each test creates uniquely-named projects for isolation
- Tests clean up after themselves
- Handles three dialog types: `window.confirm`, `window.prompt`, and custom overlay dialog
- Helper functions: `addProject()`, `sidebarProject()`, `manageProject()`, `openManageModal()`, etc.

## Test plan
- [ ] CI will run with `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` secrets

Fixes #329

Generated with [Claude Code](https://claude.com/claude-code)