### PR TITLE
Add E2E area tests (fixes #330)

### DIFF
--- a/tests/e2e/areas.spec.js
+++ b/tests/e2e/areas.spec.js
@@ -117,7 +117,7 @@ test.describe('Areas', () => {
 
     test('rename an area via Manage Areas modal', async ({ authedPage }) => {
         const name = unique()
-        const newName = `${name}-renamed`
+        const newName = `Ren-${Date.now()}`
         await addArea(authedPage, name)
 
         await openManageAreasModal(authedPage)
@@ -129,9 +129,11 @@ test.describe('Areas', () => {
         const nameInput = authedPage.locator('.manage-areas-name-input')
         await expect(nameInput).toBeVisible({ timeout: 3000 })
 
-        // Verify fill works
-        await nameInput.fill(newName)
-        await expect(nameInput).toHaveValue(newName)
+        // Set new name value directly to avoid fill() being interrupted by blur race
+        await nameInput.evaluate((el, val) => {
+            el.value = val
+            el.dispatchEvent(new Event('input', { bubbles: true }))
+        }, newName)
 
         // Trigger blur to invoke saveEdit
         await nameInput.evaluate(el => el.blur())
@@ -139,17 +141,9 @@ test.describe('Areas', () => {
         // Wait for the async rename to complete (input disappears after re-render)
         await expect(nameInput).not.toBeAttached({ timeout: 10000 })
 
-        // Debug: log what manage-areas-name elements contain after re-render
-        const namesAfterRename = await authedPage.locator('.manage-areas-name').allTextContents()
-        console.log('Area names after rename re-render:', JSON.stringify(namesAfterRename))
-
         // Close and re-open modal to get a fresh render from the store
         await closeManageAreasModal(authedPage)
         await openManageAreasModal(authedPage)
-
-        // Debug: log what manage-areas-name elements contain after re-open
-        const namesAfterReopen = await authedPage.locator('.manage-areas-name').allTextContents()
-        console.log('Area names after modal re-open:', JSON.stringify(namesAfterReopen))
 
         // Verify renamed in modal
         await expect(manageAreaItem(authedPage, newName)).toBeVisible({ timeout: 5000 })


### PR DESCRIPTION
## Summary
- Adds comprehensive Playwright E2E tests for area management functionality
- Covers 8 test cases: CRUD operations, filtering, keyboard shortcuts, project assignment, and color picker

## Changes
- New file: `tests/e2e/areas.spec.js` with 8 test cases:
  1. Add a new area
  2. Rename an area via Manage Areas modal
  3. Delete an area
  4. Filter by area shows only area projects
  5. Unassigned filter shows projects without an area
  6. Area keyboard shortcuts switch between areas
  7. Assign a project to an area via manage modal
  8. Area color picker works

## Test plan
- [ ] All 8 area tests pass in CI
- [ ] Existing auth, todo, and project tests still pass
- [ ] No test interference due to unique naming (`Area-${Date.now()}-...`)

Fixes #330

Generated with [Claude Code](https://claude.com/claude-code)