### PR TITLE
Add E2E search and filtering tests (fixes #332)

### DIFF
--- a/tests/e2e/search.spec.js
+++ b/tests/e2e/search.spec.js
@@ -216,7 +216,8 @@ test.describe('Search and Filtering', () => {
     })
 
     test('empty search results show appropriate message', async ({ authedPage }) => {
-        await switchGtdTab(authedPage, 'inbox')
+        // Use "All" tab since Inbox shows a special zen state when empty
+        await switchGtdTab(authedPage, 'all')
 
         // Search for something that doesn't exist
         await search(authedPage, 'zzz-absolutely-no-match-zzz')


### PR DESCRIPTION
## Summary
- Adds comprehensive Playwright E2E tests for search and filtering functionality
- Covers all 6 test cases from issue #332

## Changes
- New file: `tests/e2e/search.spec.js` with 6 test cases:
  1. Search input filters todos by text
  2. Search is case-insensitive
  3. Clearing search shows all todos again
  4. Search works across different GTD statuses
  5. Search combined with project filter
  6. Empty search results show appropriate message

## Test plan
- [ ] All 6 search tests pass in CI
- [ ] Existing tests still pass
- [ ] Search debounce handled via `waitForTimeout(600)`

Fixes #332

Generated with [Claude Code](https://claude.com/claude-code)