### PR TITLE
Add E2E settings tests - theme and density (fixes #334)

### DIFF
--- a/tests/e2e/settings.spec.js
+++ b/tests/e2e/settings.spec.js
@@ -1,0 +1,119 @@
+import { test, expect } from './fixtures.js'
+
+test.describe('Settings - Theme', () => {
+    test('change theme to Dark and verify it applies', async ({ authedPage }) => {
+        // Change to Dark theme
+        await authedPage.selectOption('#themeSelect', 'dark')
+
+        // Verify data-theme attribute is set on <html>
+        await expect(authedPage.locator('html')).toHaveAttribute('data-theme', 'dark')
+
+        // Verify the select shows the correct value
+        await expect(authedPage.locator('#themeSelect')).toHaveValue('dark')
+    })
+
+    test('change theme to Clear and verify it applies', async ({ authedPage }) => {
+        await authedPage.selectOption('#themeSelect', 'clear')
+        await expect(authedPage.locator('html')).toHaveAttribute('data-theme', 'clear')
+        await expect(authedPage.locator('#themeSelect')).toHaveValue('clear')
+    })
+
+    test('change theme to Glass and verify it applies', async ({ authedPage }) => {
+        // First switch away from Glass (default)
+        await authedPage.selectOption('#themeSelect', 'dark')
+        await expect(authedPage.locator('html')).toHaveAttribute('data-theme', 'dark')
+
+        // Switch back to Glass
+        await authedPage.selectOption('#themeSelect', 'glass')
+        await expect(authedPage.locator('html')).toHaveAttribute('data-theme', 'glass')
+    })
+
+    test('theme persists after page reload', async ({ authedPage }) => {
+        // Change to Dark theme
+        await authedPage.selectOption('#themeSelect', 'dark')
+        await expect(authedPage.locator('html')).toHaveAttribute('data-theme', 'dark')
+
+        // Wait for the setting to be saved to Supabase
+        await authedPage.waitForTimeout(1000)
+
+        // Reload the page
+        await authedPage.reload()
+        await authedPage.waitForLoadState('networkidle')
+
+        // Theme should still be dark after reload
+        await expect(authedPage.locator('html')).toHaveAttribute('data-theme', 'dark', { timeout: 10000 })
+        await expect(authedPage.locator('#themeSelect')).toHaveValue('dark', { timeout: 10000 })
+
+        // Restore to default (glass) for other tests
+        await authedPage.selectOption('#themeSelect', 'glass')
+        await authedPage.waitForTimeout(1000)
+    })
+})
+
+test.describe('Settings - Density', () => {
+    test('change density to Compact and verify it applies', async ({ authedPage }) => {
+        await authedPage.selectOption('#densitySelect', 'compact')
+        await expect(authedPage.locator('html')).toHaveAttribute('data-density', 'compact')
+        await expect(authedPage.locator('#densitySelect')).toHaveValue('compact')
+    })
+
+    test('change density to Comfortable and verify it applies', async ({ authedPage }) => {
+        // First switch to compact
+        await authedPage.selectOption('#densitySelect', 'compact')
+        await expect(authedPage.locator('html')).toHaveAttribute('data-density', 'compact')
+
+        // Switch back to comfortable
+        await authedPage.selectOption('#densitySelect', 'comfortable')
+        await expect(authedPage.locator('html')).toHaveAttribute('data-density', 'comfortable')
+    })
+
+    test('density persists after page reload', async ({ authedPage }) => {
+        // Change to Compact density
+        await authedPage.selectOption('#densitySelect', 'compact')
+        await expect(authedPage.locator('html')).toHaveAttribute('data-density', 'compact')
+
+        // Wait for the setting to be saved to Supabase
+        await authedPage.waitForTimeout(1000)
+
+        // Reload the page
+        await authedPage.reload()
+        await authedPage.waitForLoadState('networkidle')
+
+        // Density should still be compact after reload
+        await expect(authedPage.locator('html')).toHaveAttribute('data-density', 'compact', { timeout: 10000 })
+        await expect(authedPage.locator('#densitySelect')).toHaveValue('compact', { timeout: 10000 })
+
+        // Restore to default (comfortable) for other tests
+        await authedPage.selectOption('#densitySelect', 'comfortable')
+        await authedPage.waitForTimeout(1000)
+    })
+})
+
+test.describe('Settings - Saved per user', () => {
+    test('settings are stored in Supabase for the authenticated user', async ({ authedPage }) => {
+        // Change both theme and density
+        await authedPage.selectOption('#themeSelect', 'clear')
+        await authedPage.selectOption('#densitySelect', 'compact')
+
+        // Wait for settings to save to Supabase
+        await authedPage.waitForTimeout(1000)
+
+        // Clear localStorage to prove settings come from the database
+        await authedPage.evaluate(() => {
+            localStorage.removeItem('colorTheme')
+            localStorage.removeItem('densityMode')
+        })
+
+        // Reload — settings should be restored from Supabase
+        await authedPage.reload()
+        await authedPage.waitForLoadState('networkidle')
+
+        await expect(authedPage.locator('html')).toHaveAttribute('data-theme', 'clear', { timeout: 10000 })
+        await expect(authedPage.locator('html')).toHaveAttribute('data-density', 'compact', { timeout: 10000 })
+
+        // Restore defaults
+        await authedPage.selectOption('#themeSelect', 'glass')
+        await authedPage.selectOption('#densitySelect', 'comfortable')
+        await authedPage.waitForTimeout(1000)
+    })
+})


### PR DESCRIPTION
## Summary
Adds comprehensive E2E tests for user settings (theme and density mode) as requested in #334.

## Problem
No authenticated E2E test coverage existed for the theme/density settings UI interactions and their persistence via Supabase.

## Solution
Created `tests/e2e/settings.spec.js` with 8 test cases covering all checklist items from the issue, using the `authedPage` fixture for authenticated testing.

## Changes
- `tests/e2e/settings.spec.js` — New test file with three describe blocks:

### Theme tests (4 tests)
- Change theme to Dark and verify `data-theme` attribute applies
- Change theme to Clear and verify it applies
- Change theme to Glass (from another theme) and verify it applies
- Theme persists after page reload

### Density tests (3 tests)
- Change density to Compact and verify `data-density` attribute applies
- Change density to Comfortable (from Compact) and verify it applies
- Density mode persists after page reload

### Per-user persistence (1 test)
- Settings are saved per-user in Supabase — verified by clearing localStorage and reloading to confirm settings restore from the database, not local storage

## Testing
- [x] CSS validation passes (`npm run check:css`)
- [x] JavaScript syntax valid
- [x] Follows existing E2E test patterns (authedPage fixture, cleanup/restore)

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)