### PR TITLE
Fix flaky settings E2E test

### DIFF
--- a/tests/e2e/settings.spec.js
+++ b/tests/e2e/settings.spec.js
@@ -12,20 +12,29 @@ async function waitForSettingsLoaded(page) {
 
 /**
  * Helper: change theme and wait for the Supabase save to complete.
+ * We start listening for the response BEFORE triggering the change,
+ * because the save is a fire-and-forget async call inside the change
+ * event handler — networkidle can fire before the request even starts.
  */
 async function changeTheme(page, theme) {
+    const saved = page.waitForResponse(
+        resp => resp.url().includes('user_settings') && resp.request().method() !== 'GET'
+    )
     await page.selectOption('#themeSelect', theme)
     await expect(page.locator('html')).toHaveAttribute('data-theme', theme)
-    await page.waitForLoadState('networkidle')
+    await saved
 }
 
 /**
  * Helper: change density and wait for the Supabase save to complete.
  */
 async function changeDensity(page, density) {
+    const saved = page.waitForResponse(
+        resp => resp.url().includes('user_settings') && resp.request().method() !== 'GET'
+    )
     await page.selectOption('#densitySelect', density)
     await expect(page.locator('html')).toHaveAttribute('data-density', density)
-    await page.waitForLoadState('networkidle')
+    await saved
 }
 
 test.describe('Settings - Theme', () => {


### PR DESCRIPTION
## Summary
- Fix race condition in settings tests where `loadThemeFromDatabase()` / `loadDensityFromDatabase()` responses could overwrite test-initiated theme changes
- Replace arbitrary `waitForTimeout(1000)` calls with `waitForLoadState('networkidle')` for reliable Supabase sync
- Add default restoration at end of each test to prevent cross-test contamination

## Root cause
After login, `app.js` line 704-705 fires `loadThemeFromDatabase()` and `loadDensityFromDatabase()` **without `await`**. When a test immediately changes the theme via `selectOption`, the async Supabase response can arrive afterwards and overwrite the change back to the database value.

## Test plan
- [ ] Settings tests pass consistently in CI (no more flaky failures)
- [ ] PR #364 (version bump) can auto-merge once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)