### PR TITLE
Fix flaky sidebar resize E2E test

### DIFF
--- a/tests/e2e/sidebar.spec.js
+++ b/tests/e2e/sidebar.spec.js
@@ -9,21 +9,16 @@ test.describe('Sidebar Resize', () => {
         const handle = authedPage.locator('#sidebarResizeHandle')
         await expect(handle).toBeVisible()
 
-        // Get initial sidebar width
         const sidebar = authedPage.locator('.sidebar')
         const initialWidth = await sidebar.evaluate(el => el.getBoundingClientRect().width)
 
-        // Get handle position
-        const handleBox = await handle.boundingBox()
-
-        // Drag handle to the right (increase sidebar width)
-        await authedPage.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
-        await authedPage.mouse.down()
-        await authedPage.mouse.move(handleBox.x + 50, handleBox.y + handleBox.height / 2, { steps: 10 })
+        // Simulate drag by dispatching mouse events directly on the element
+        // This avoids flakiness from mouse.move missing the thin handle in headless CI
+        await handle.dispatchEvent('mousedown', { clientX: 200, clientY: 300 })
+        await authedPage.mouse.move(280, 300, { steps: 10 })
         await authedPage.mouse.up()
         await authedPage.waitForTimeout(300)
 
-        // Sidebar width should have changed
         const newWidth = await sidebar.evaluate(el => el.getBoundingClientRect().width)
         expect(newWidth).not.toBe(initialWidth)
     })
@@ -31,33 +26,27 @@ test.describe('Sidebar Resize', () => {
     test('sidebar width is constrained between 15% and 30%', async ({ authedPage }) => {
         const handle = authedPage.locator('#sidebarResizeHandle')
         const sidebar = authedPage.locator('.sidebar')
-        const container = authedPage.locator('.app-container')
-
-        const handleBox = await handle.boundingBox()
-        const containerWidth = await container.evaluate(el => el.getBoundingClientRect().width)
+        const containerWidth = await authedPage.locator('.main-content').evaluate(el => el.getBoundingClientRect().width)
 
         // Drag handle far to the left (try to make sidebar very narrow)
-        await authedPage.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
-        await authedPage.mouse.down()
-        await authedPage.mouse.move(0, handleBox.y + handleBox.height / 2, { steps: 10 })
+        await handle.dispatchEvent('mousedown', { clientX: 200, clientY: 300 })
+        await authedPage.mouse.move(0, 300, { steps: 10 })
         await authedPage.mouse.up()
 
         // Sidebar should not go below 15%
         const narrowWidth = await sidebar.evaluate(el => el.getBoundingClientRect().width)
         const narrowPercent = (narrowWidth / containerWidth) * 100
-        expect(narrowPercent).toBeGreaterThanOrEqual(12) // tolerance for CI viewport
+        expect(narrowPercent).toBeGreaterThanOrEqual(12)
 
         // Drag handle far to the right (try to make sidebar very wide)
-        const handleBox2 = await handle.boundingBox()
-        await authedPage.mouse.move(handleBox2.x + handleBox2.width / 2, handleBox2.y + handleBox2.height / 2)
-        await authedPage.mouse.down()
-        await authedPage.mouse.move(containerWidth * 0.5, handleBox2.y + handleBox2.height / 2, { steps: 10 })
+        await handle.dispatchEvent('mousedown', { clientX: 100, clientY: 300 })
+        await authedPage.mouse.move(containerWidth * 0.5, 300, { steps: 10 })
         await authedPage.mouse.up()
 
         // Sidebar should not exceed 30%
         const wideWidth = await sidebar.evaluate(el => el.getBoundingClientRect().width)
         const widePercent = (wideWidth / containerWidth) * 100
-        expect(widePercent).toBeLessThanOrEqual(35) // tolerance for CI viewport
+        expect(widePercent).toBeLessThanOrEqual(35)
     })
 })
 


### PR DESCRIPTION
## Summary
- Fix sidebar drag tests that fail in headless CI because `mouse.move` + `mouse.down` misses the thin resize handle
- Use `handle.dispatchEvent('mousedown')` to guarantee the mousedown lands on the handle, then `mouse.move`/`mouse.up` for the drag
- Use `.main-content` for container width calculation (matches `app.js` line 1077)

## Root cause
The resize handle is very thin (a few pixels). In headless CI, Playwright's `mouse.move` to the handle center followed by `mouse.down` can miss the element, so `isResizing` never becomes `true` and the drag has no effect. Dispatching `mousedown` directly on the handle element bypasses this coordinate precision issue.

## Test plan
- [ ] Sidebar resize tests pass consistently in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)