### PR TITLE
Add E2E tests for recurrence UI, weekday checkboxes, GTD guide, and modal escape

### DIFF
--- a/tests/e2e/recurrence-ui.spec.js
+++ b/tests/e2e/recurrence-ui.spec.js
@@ -87,9 +87,14 @@ test.describe('Recurrence Interval', () => {
     })
 
     test('custom interval value can be set', async ({ authedPage }) => {
-        await openRepeatTab(authedPage)
+        // Open modal and fill details tab fields first (due date is on the details tab)
+        await authedPage.click('#openAddTodoModal')
+        await expect(authedPage.locator('#addTodoModal')).toBeVisible()
         await authedPage.fill('#modalTodoInput', 'interval-test')
         await authedPage.fill('#modalDueDateInput', getTomorrowDate())
+        // Now switch to repeat tab
+        await authedPage.click('.modal-tab[data-tab="repeat"]')
+        await expect(authedPage.locator('.modal-tab-panel[data-panel="repeat"]')).toHaveClass(/active/, { timeout: 3000 })
         await authedPage.selectOption('#modalRepeatSelect', 'daily')
         await authedPage.waitForTimeout(300)
 
@@ -180,13 +185,14 @@ test.describe('Weekly Weekday Checkboxes', () => {
         await authedPage.waitForTimeout(300)
 
         const mondayCheckbox = authedPage.locator('input[name="weekday"][value="1"]')
+        const mondayLabel = authedPage.locator('.weekday-checkbox:has(input[value="1"])')
 
-        // Toggle Monday on
-        await mondayCheckbox.check()
+        // Toggle Monday on (click the label since the input is visually hidden)
+        await mondayLabel.click()
         await expect(mondayCheckbox).toBeChecked()
 
         // Toggle Monday off
-        await mondayCheckbox.uncheck()
+        await mondayLabel.click()
         await expect(mondayCheckbox).not.toBeChecked()
 
         await authedPage.keyboard.press('Escape')
@@ -289,6 +295,10 @@ test.describe('Modal Escape Handling', () => {
         await authedPage.click('#settingsBtn')
         await expect(authedPage.locator('#settingsModal')).toHaveClass(/active/, { timeout: 5000 })
 
+        // Wait for the username input to receive focus — this happens via setTimeout(100ms)
+        // AFTER the Escape handler is registered in ModalManager.open, which itself waits
+        // for the async onOpen (loadSettingsModalData with network call) to complete first.
+        await expect(authedPage.locator('#usernameInput')).toBeFocused({ timeout: 10000 })
         await authedPage.keyboard.press('Escape')
         await expect(authedPage.locator('#settingsModal')).not.toHaveClass(/active/, { timeout: 5000 })
     })


### PR DESCRIPTION
## Summary
- Adds 17 new E2E tests covering previously untested UI features
- **Recurrence Interval** (4 tests): interval input visibility, label changes per type, custom value, options hide on "none"
- **Weekly Weekday Checkboxes** (5 tests): checkbox visibility, hidden for daily, weekdays preset (Mon-Fri), weekends preset (Sat-Sun), individual toggle
- **Monthly Options** (2 tests): monthly options visibility, weekday select toggle
- **GTD Guide Modal** (1 test): opens from menu, has title and content
- **Modal Escape Handling** (5 tests): ESC closes add todo, export, import, manage projects, and settings modals

## Test plan
- [ ] All 17 tests pass in CI
- [ ] No flakiness from modal open/close timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)