### PR TITLE
Add date grouping to Project view

### DIFF
--- a/src/services/todos-filters.js
+++ b/src/services/todos-filters.js
@@ -77,6 +77,15 @@ export function getFilteredTodos() {
             if (!b.due_date) return -1
             return a.due_date.localeCompare(b.due_date)
         })
+    } else if (state.selectedProjectId !== null) {
+        // Project view: exclude done, sort by due date (items with dates first, then without)
+        filtered = filtered.filter(t => t.gtd_status !== 'done')
+        return filtered.slice().sort((a, b) => {
+            if (!a.due_date && !b.due_date) return 0
+            if (!a.due_date) return 1
+            if (!b.due_date) return -1
+            return a.due_date.localeCompare(b.due_date)
+        })
     } else if (state.selectedGtdStatus === 'done') {
         // Show only done items when Done tab is selected
         filtered = filtered.filter(t => t.gtd_status === 'done')

--- a/src/ui/TodoList.js
+++ b/src/ui/TodoList.js
@@ -215,13 +215,14 @@ export function renderTodos(container, options = {}) {
     let currentDateGroup = null
 
     filteredTodos.forEach(todo => {
-        // Add section header for Scheduled view
-        if (state.selectedGtdStatus === 'scheduled' && todo.due_date) {
-            const dateGroup = getDateGroup(todo.due_date)
+        // Add section header for Scheduled and Project views
+        if (state.selectedGtdStatus === 'scheduled' || state.selectedProjectId !== null) {
+            const dateGroup = todo.due_date ? getDateGroup(todo.due_date) : 'no-date'
             if (dateGroup !== currentDateGroup) {
                 currentDateGroup = dateGroup
                 const header = document.createElement('li')
                 header.className = `scheduled-section-header ${dateGroup}`
+                // Note: getDateGroupLabel returns safe static strings from a fixed map
                 header.innerHTML = `<span class="section-header-text">${escapeHtml(getDateGroupLabel(dateGroup))}</span>`
                 container.appendChild(header)
             }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -85,7 +85,8 @@ export function getDateGroupLabel(group) {
         'tomorrow': 'Tomorrow',
         'this-week': 'This Week',
         'next-week': 'Next Week',
-        'later': 'Later'
+        'later': 'Later',
+        'no-date': 'No Date'
     }
     return labels[group] || group
 }

--- a/styles.css
+++ b/styles.css
@@ -1215,6 +1215,10 @@ body.sidebar-resizing * {
     background: linear-gradient(135deg, #95a5a6 0%, #7f8c8d 100%);
 }
 
+.scheduled-section-header.no-date {
+    background: linear-gradient(135deg, #bdc3c7 0%, #a6acaf 100%);
+}
+
 .section-header-text {
     display: flex;
     align-items: center;
@@ -5428,6 +5432,13 @@ body.sidebar-resizing * {
 [data-theme="glass"] .scheduled-section-header.later,
 [data-theme="dark"] .scheduled-section-header.later,
 [data-theme="clear"] .scheduled-section-header.later {
+    background: var(--ios-gray5);
+    color: var(--ios-label-secondary);
+}
+
+[data-theme="glass"] .scheduled-section-header.no-date,
+[data-theme="dark"] .scheduled-section-header.no-date,
+[data-theme="clear"] .scheduled-section-header.no-date {
     background: var(--ios-gray5);
     color: var(--ios-label-secondary);
 }


### PR DESCRIPTION
## Summary
- Tasks in the Project view are now grouped by date headers (Overdue, Today, Tomorrow, This Week, Next Week, Later, No Date) — matching the existing Scheduled GTD view
- Tasks with due dates are sorted earliest-first; tasks without dates appear at the end under a "No Date" header
- Reuses existing date grouping infrastructure (`getDateGroup`, `getDateGroupLabel`, `scheduled-section-header` CSS)

## Changes
| File | Change |
|------|--------|
| `src/services/todos-filters.js` | Added project view branch: exclude done tasks, sort by due date |
| `src/ui/TodoList.js` | Extended date group header rendering to project view, handle null dates |
| `src/utils/dates.js` | Added `'no-date': 'No Date'` label for tasks without a due date |
| `styles.css` | Added `.no-date` header styles for default and iOS themes |

## Test plan
- [ ] Open a project with tasks that have various due dates → verify grouped headers appear
- [ ] Verify tasks without due dates appear under "No Date" at the bottom
- [ ] Verify Scheduled GTD view still works identically
- [ ] Test with Glass, Dark, and Clear themes for correct header styling
- [ ] Verify an empty project still shows the empty state message

🤖 Generated with [Claude Code](https://claude.com/claude-code)