### PR TITLE
Add E2E tests for URL navigation and browser history

### DIFF
--- a/tests/e2e/navigation.spec.js
+++ b/tests/e2e/navigation.spec.js
@@ -118,7 +118,7 @@ test.describe('URL Navigation - GTD Deep Linking', () => {
 test.describe('URL Navigation - View Deep Linking', () => {
     test('?view=projects shows the All Projects view', async ({ authedPage }) => {
         await navigateTo(authedPage, '/?view=projects')
-        await expect(authedPage.locator('.project-card')).toBeVisible({ timeout: 5000 })
+        await expect(authedPage.locator('.project-card').first()).toBeVisible({ timeout: 5000 })
     })
 
     test('?view=today selects Scheduled tab', async ({ authedPage }) => {


### PR DESCRIPTION
## Summary
- 17 new E2E tests covering URL navigation and routing (`navigation.spec.js`)
- Tests the `src/services/navigation.js` module end-to-end

## Test Categories

### GTD Deep Linking (8 tests)
- `?gtd=next_action`, `?gtd=scheduled`, `?gtd=waiting_for`, `?gtd=someday_maybe`, `?gtd=done`, `?gtd=all` all select the correct tab
- Invalid `?gtd=` value defaults to Inbox
- No query params defaults to Inbox

### View Deep Linking (4 tests)
- `?view=projects` shows All Projects view
- `?view=today` and `?view=tomorrow` select Scheduled tab
- `?project=<id>` selects and highlights the project

### URL Sync on Interaction (3 tests)
- Switching GTD tabs updates URL query param
- Selecting a project updates URL with `?project=`
- Switching from project to GTD tab removes `?project=` and adds `?gtd=`

### Browser History (2 tests)
- Browser back button restores previous GTD state
- Browser forward button restores forward GTD state

## Test plan
- [ ] All 17 tests pass in CI
- [ ] No impact on existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)