### PR TITLE
Add E2E tests for project view date grouping

### DIFF
--- a/tests/e2e/project-date-grouping.spec.js
+++ b/tests/e2e/project-date-grouping.spec.js
@@ -74,8 +74,16 @@ async function selectProject(page, name) {
 async function deleteProject(page, name) {
     const item = page.locator('#projectList .project-item', { has: page.locator('.project-name', { hasText: name }) })
     if (await item.count() > 0) {
+        // Projects with todos show a custom DOM dialog instead of browser confirm
         page.once('dialog', dialog => dialog.accept())
         await item.locator('.project-delete').click()
+
+        // Handle custom delete dialog (shown when project has todos)
+        const customDialog = page.locator('.delete-project-dialog-overlay')
+        if (await customDialog.isVisible({ timeout: 1000 }).catch(() => false)) {
+            await customDialog.locator('[data-action="delete"]').click()
+        }
+
         await expect(item).not.toBeAttached({ timeout: 5000 })
     }
 }


### PR DESCRIPTION
## Summary
- 5 new E2E tests validating the project view date grouping feature (`project-date-grouping.spec.js`)
- Tests the feature added in PR #377

## Tests

| Test | What it validates |
|------|-------------------|
| Groups todos by date sections | Today/Tomorrow headers appear when project has dated todos |
| Shows No Date section | Todos without due dates get a "No Date" header |
| Shows Overdue section | Past-due todos grouped under "Overdue" header |
| Excludes done todos | Completed todos don't appear in project view |
| Sorts by due date ascending | Earlier dates appear before later dates in DOM |

## Test plan
- [ ] All 5 tests pass in CI
- [ ] No impact on existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)