### PR TITLE
Add empty states & edge cases E2E tests (Group 9)

### DIFF
--- a/tests/e2e/empty-states.spec.js
+++ b/tests/e2e/empty-states.spec.js
@@ -1,54 +1,14 @@
 import { test, expect } from './fixtures.js'
-
-const unique = () => `ES-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
-
-/**
- * Helper: add a todo via the modal.
- */
-async function addTodo(page, text) {
-    await page.click('#openAddTodoModal')
-    await expect(page.locator('#addTodoModal')).toBeVisible()
-    await page.fill('#modalTodoInput', text)
-    await page.click('#addTodoForm button[type="submit"]')
-    await expect(page.locator('#addTodoModal')).not.toBeVisible({ timeout: 5000 })
-}
-
-/**
- * Helper: find a todo item by its text content.
- */
-function todoItem(page, text) {
-    return page.locator('.todo-item', { has: page.locator('.todo-text', { hasText: text }) })
-}
-
-/**
- * Helper: click a GTD tab.
- */
-async function switchGtdTab(page, status) {
-    await page.click(`.gtd-tab.${status}`)
-    await page.waitForTimeout(500)
-}
-
-/**
- * Helper: delete a todo by text.
- */
-async function deleteTodo(page, text) {
-    const item = todoItem(page, text)
-    if (await item.count() > 0) {
-        await item.locator('.delete-btn').click()
-        await expect(item).not.toBeAttached({ timeout: 5000 })
-    }
-}
+import { unique, addTodo, todoItem, deleteTodo, switchGtdTab } from './helpers/todos.js'
 
 test.describe('Empty States', () => {
-    test('empty GTD tab shows no todo items', async ({ authedPage }) => {
-        // Switch to Someday tab — likely empty for test user
+    test('switching to a GTD tab renders without errors', async ({ authedPage }) => {
+        // Switch to Someday tab and verify it activates
         await switchGtdTab(authedPage, 'someday_maybe')
+        await expect(authedPage.locator('.gtd-tab.someday_maybe')).toHaveClass(/active/)
 
-        // Should have no todo items with our unique prefix
-        const todoItems = authedPage.locator('.todo-item')
-        // We can't guarantee the tab is completely empty, but we verify
-        // the tab renders without errors
-        await authedPage.waitForTimeout(500)
+        // The todo list container should be present (renders either items or empty state)
+        await expect(authedPage.locator('#todoList')).toBeVisible()
 
         // Return to Inbox
         await switchGtdTab(authedPage, 'inbox')
@@ -59,15 +19,12 @@ test.describe('Empty States', () => {
 
         // Type a search query that matches nothing
         await authedPage.fill('#searchInput', nonsense)
-        await authedPage.waitForTimeout(500)
 
         // No todo items should be visible
-        const todoItems = authedPage.locator('.todo-item')
-        await expect(todoItems).toHaveCount(0, { timeout: 5000 })
+        await expect(authedPage.locator('.todo-item')).toHaveCount(0, { timeout: 5000 })
 
         // Clear search
         await authedPage.fill('#searchInput', '')
-        await authedPage.waitForTimeout(500)
     })
 
     test('search with GTD filter shows empty state', async ({ authedPage }) => {
@@ -77,32 +34,25 @@ test.describe('Empty States', () => {
         // Search for nonsense
         const nonsense = `ZZZZZ-${Date.now()}-nonexistent`
         await authedPage.fill('#searchInput', nonsense)
-        await authedPage.waitForTimeout(500)
 
         // No results
-        const todoItems = authedPage.locator('.todo-item')
-        await expect(todoItems).toHaveCount(0, { timeout: 5000 })
+        await expect(authedPage.locator('.todo-item')).toHaveCount(0, { timeout: 5000 })
 
         // Clear search and return to Inbox
         await authedPage.fill('#searchInput', '')
         await switchGtdTab(authedPage, 'inbox')
     })
 
-    test('adding and deleting a todo restores empty state', async ({ authedPage }) => {
-        // Switch to Someday tab (likely empty)
+    test('adding and deleting a todo restores original count', async ({ authedPage }) => {
+        // Switch to Someday tab
         await switchGtdTab(authedPage, 'someday_maybe')
 
         // Count existing items
         const countBefore = await authedPage.locator('.todo-item').count()
 
-        // Add a todo and move it to Someday via the modal
-        const name = unique()
-        await authedPage.click('#openAddTodoModal')
-        await expect(authedPage.locator('#addTodoModal')).toBeVisible()
-        await authedPage.fill('#modalTodoInput', name)
-        await authedPage.selectOption('#modalGtdStatusSelect', 'someday_maybe')
-        await authedPage.click('#addTodoForm button[type="submit"]')
-        await expect(authedPage.locator('#addTodoModal')).not.toBeVisible({ timeout: 5000 })
+        // Add a todo directly to Someday
+        const name = unique('ES')
+        await addTodo(authedPage, name, { gtdStatus: 'someday_maybe' })
 
         // Todo should appear in Someday tab
         await expect(todoItem(authedPage, name)).toBeVisible({ timeout: 5000 })

--- a/tests/e2e/helpers/todos.js
+++ b/tests/e2e/helpers/todos.js
@@ -37,6 +37,9 @@ export async function addTodo(page, text, opts = {}) {
     if (opts.priority) {
         await page.selectOption('#modalPrioritySelect', { label: opts.priority })
     }
+    if (opts.gtdStatus) {
+        await page.selectOption('#modalGtdStatusSelect', opts.gtdStatus)
+    }
 
     await page.click('#addTodoForm button[type="submit"]')
     await expect(page.locator('#addTodoModal')).not.toBeVisible({ timeout: 5000 })
@@ -88,6 +91,16 @@ export async function deleteProject(page, name) {
     page.once('dialog', dialog => dialog.accept())
     await item.locator('.project-delete').click()
     await expect(item).not.toBeAttached({ timeout: 5000 })
+}
+
+/**
+ * Switch to a GTD tab in the sidebar and wait for it to become active.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} status - GTD tab class name (e.g. 'inbox', 'someday_maybe', 'waiting_for')
+ */
+export async function switchGtdTab(page, status) {
+    await page.click(`.gtd-tab.${status}`)
+    await expect(page.locator(`.gtd-tab.${status}`)).toHaveClass(/active/, { timeout: 3000 })
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds 4 E2E tests covering empty state displays and GTD tab switching
- Uses shared helpers from `tests/e2e/helpers/todos.js`
- Adds `switchGtdTab` and `gtdStatus` option to shared helpers

## New tests in `empty-states.spec.js`
- **Switching to a GTD tab renders without errors** — tab activation and list rendering
- **Search with no results shows empty state** — zero items on nonsense query
- **Search with GTD filter shows empty state** — combined GTD + search empty state
- **Adding and deleting a todo restores original count** — item count returns to baseline

## Shared helper additions (`tests/e2e/helpers/todos.js`)
- `switchGtdTab(page, status)` — click a GTD tab and wait for it to become active
- `addTodo` now supports `opts.gtdStatus` for setting GTD status during creation

## Test plan
- [ ] All 4 new tests pass in CI
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)