### PR TITLE
Add area selection persistence E2E tests (Group 10)

### DIFF
--- a/tests/e2e/area-persistence.spec.js
+++ b/tests/e2e/area-persistence.spec.js
@@ -1,92 +1,10 @@
 import { test, expect } from './fixtures.js'
-
-const unique = () => `AP-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
-
-/**
- * Helper: open the Areas dropdown in the toolbar.
- */
-async function openAreasDropdown(page) {
-    const dropdown = page.locator('#toolbarAreasDropdown')
-    if (await dropdown.isVisible()) return
-    await page.click('#toolbarAreasBtn')
-    await expect(dropdown).toBeVisible({ timeout: 3000 })
-}
-
-/**
- * Helper: open the Manage Areas modal.
- */
-async function openManageAreasModal(page) {
-    await openAreasDropdown(page)
-    await page.click('#manageAreasBtn')
-    await expect(page.locator('#manageAreasModal')).toBeVisible({ timeout: 5000 })
-}
-
-/**
- * Helper: close the Manage Areas modal.
- */
-async function closeManageAreasModal(page) {
-    await page.click('#closeManageAreasModalBtn')
-    await expect(page.locator('#manageAreasModal')).not.toBeVisible({ timeout: 5000 })
-}
-
-/**
- * Helper: create an area via the manage areas modal.
- */
-async function createArea(page, name) {
-    await openManageAreasModal(page)
-    await page.fill('#newAreaInput', name)
-    await page.click('#addNewAreaBtn')
-    await expect(page.locator('.manage-areas-item', {
-        has: page.locator('.manage-areas-name', { hasText: name })
-    })).toBeVisible({ timeout: 5000 })
-    await closeManageAreasModal(page)
-}
-
-/**
- * Helper: delete an area via the manage areas modal.
- */
-async function deleteArea(page, name) {
-    await openManageAreasModal(page)
-    const item = page.locator('.manage-areas-item', {
-        has: page.locator('.manage-areas-name', { hasText: name })
-    })
-    if (await item.count() > 0) {
-        page.once('dialog', d => d.accept())
-        await item.locator('.manage-areas-delete').click()
-        await expect(item).not.toBeAttached({ timeout: 5000 })
-    }
-    await closeManageAreasModal(page)
-}
-
-/**
- * Helper: select an area from the toolbar dropdown.
- */
-async function selectArea(page, name) {
-    await openAreasDropdown(page)
-    const dropdown = page.locator('#toolbarAreasDropdown')
-    await dropdown.locator('.toolbar-areas-item', { hasText: name }).click()
-    await page.waitForTimeout(500)
-}
-
-/**
- * Helper: get the current area label text.
- */
-async function getCurrentAreaLabel(page) {
-    return (await page.locator('#toolbarAreasLabel').textContent()).trim()
-}
-
-/**
- * Helper: wait for app to be fully ready after reload.
- */
-async function waitForApp(page) {
-    await expect(page.locator('#appContainer')).toHaveClass(/active/, { timeout: 30000 })
-    await expect(page.locator('body')).toHaveClass(/fullscreen-mode/, { timeout: 10000 })
-    await page.waitForTimeout(2000)
-}
+import { unique, waitForApp } from './helpers/todos.js'
+import { createArea, deleteArea, selectArea, getCurrentAreaLabel, openAreasDropdown } from './helpers/areas.js'
 
 test.describe('Area Selection Persistence', () => {
     test('area selection persists after page reload', async ({ authedPage }) => {
-        const areaName = unique()
+        const areaName = unique('AP')
         await createArea(authedPage, areaName)
 
         // Select the area
@@ -111,7 +29,7 @@ test.describe('Area Selection Persistence', () => {
     })
 
     test('deleting selected area resets to All Areas', async ({ authedPage }) => {
-        const areaName = unique()
+        const areaName = unique('AP')
         await createArea(authedPage, areaName)
 
         // Select the area
@@ -121,15 +39,13 @@ test.describe('Area Selection Persistence', () => {
 
         // Delete the area
         await deleteArea(authedPage, areaName)
-        await authedPage.waitForTimeout(500)
 
         // Should reset to All Areas
-        const labelAfter = await getCurrentAreaLabel(authedPage)
-        expect(labelAfter.toLowerCase()).toContain('all')
+        await expect(authedPage.locator('#toolbarAreasLabel')).toContainText(/all/i, { timeout: 3000 })
     })
 
     test('Shift+0 resets to All Areas', async ({ authedPage }) => {
-        const areaName = unique()
+        const areaName = unique('AP')
         await createArea(authedPage, areaName)
 
         // Select the area
@@ -139,11 +55,9 @@ test.describe('Area Selection Persistence', () => {
 
         // Press Shift+0 to reset
         await authedPage.keyboard.press('Shift+0')
-        await authedPage.waitForTimeout(500)
 
         // Should show All Areas
-        const labelAfter = await getCurrentAreaLabel(authedPage)
-        expect(labelAfter.toLowerCase()).toContain('all')
+        await expect(authedPage.locator('#toolbarAreasLabel')).toContainText(/all/i, { timeout: 3000 })
 
         // Cleanup
         await deleteArea(authedPage, areaName)

--- a/tests/e2e/helpers/areas.js
+++ b/tests/e2e/helpers/areas.js
@@ -1,0 +1,85 @@
+import { expect } from '@playwright/test'
+
+/**
+ * Open the Areas dropdown in the toolbar.
+ * No-op if already open.
+ * @param {import('@playwright/test').Page} page
+ */
+export async function openAreasDropdown(page) {
+    const dropdown = page.locator('#toolbarAreasDropdown')
+    if (await dropdown.isVisible()) return
+    await page.click('#toolbarAreasBtn')
+    await expect(dropdown).toBeVisible({ timeout: 3000 })
+}
+
+/**
+ * Open the Manage Areas modal (opens dropdown first if needed).
+ * @param {import('@playwright/test').Page} page
+ */
+export async function openManageAreasModal(page) {
+    await openAreasDropdown(page)
+    await page.click('#manageAreasBtn')
+    await expect(page.locator('#manageAreasModal')).toBeVisible({ timeout: 5000 })
+}
+
+/**
+ * Close the Manage Areas modal.
+ * @param {import('@playwright/test').Page} page
+ */
+export async function closeManageAreasModal(page) {
+    await page.click('#closeManageAreasModalBtn')
+    await expect(page.locator('#manageAreasModal')).not.toBeVisible({ timeout: 5000 })
+}
+
+/**
+ * Create an area via the Manage Areas modal.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name
+ */
+export async function createArea(page, name) {
+    await openManageAreasModal(page)
+    await page.fill('#newAreaInput', name)
+    await page.click('#addNewAreaBtn')
+    await expect(page.locator('.manage-areas-item', {
+        has: page.locator('.manage-areas-name', { hasText: name })
+    })).toBeVisible({ timeout: 5000 })
+    await closeManageAreasModal(page)
+}
+
+/**
+ * Delete an area via the Manage Areas modal.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name
+ */
+export async function deleteArea(page, name) {
+    await openManageAreasModal(page)
+    const item = page.locator('.manage-areas-item', {
+        has: page.locator('.manage-areas-name', { hasText: name })
+    })
+    if (await item.count() > 0) {
+        page.once('dialog', d => d.accept())
+        await item.locator('.manage-areas-delete').click()
+        await expect(item).not.toBeAttached({ timeout: 5000 })
+    }
+    await closeManageAreasModal(page)
+}
+
+/**
+ * Select an area from the toolbar dropdown and wait for label to update.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name
+ */
+export async function selectArea(page, name) {
+    await openAreasDropdown(page)
+    await page.locator('#toolbarAreasDropdown .toolbar-areas-item', { hasText: name }).click()
+    await expect(page.locator('#toolbarAreasLabel')).toContainText(name, { timeout: 3000 })
+}
+
+/**
+ * Get the current area label text from the toolbar.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<string>}
+ */
+export async function getCurrentAreaLabel(page) {
+    return (await page.locator('#toolbarAreasLabel').textContent()).trim()
+}


### PR DESCRIPTION
## Summary
- Adds 3 E2E tests covering area selection persistence and edge cases
- Extracts area helpers to `tests/e2e/helpers/areas.js` for reuse

## New tests in `area-persistence.spec.js`
- **Persists after reload** — selected area survives page reload
- **Delete resets to All** — deleting selected area resets dropdown
- **Shift+0 resets** — keyboard shortcut returns to All Areas

## Shared helper additions
- `tests/e2e/helpers/areas.js` — `openAreasDropdown`, `openManageAreasModal`, `closeManageAreasModal`, `createArea`, `deleteArea`, `selectArea`, `getCurrentAreaLabel`
- Uses `unique` and `waitForApp` from `tests/e2e/helpers/todos.js`

## Test plan
- [ ] All 3 new tests pass in CI
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)