### PR TITLE
Add notification settings E2E tests (Group 11)

### DIFF
--- a/tests/e2e/helpers/settings.js
+++ b/tests/e2e/helpers/settings.js
@@ -1,0 +1,40 @@
+import { expect } from '@playwright/test'
+
+/**
+ * Open the settings modal and wait for settings data to load from Supabase.
+ * @param {import('@playwright/test').Page} page
+ */
+export async function openSettingsModal(page) {
+    const settingsLoaded = page.waitForResponse(
+        resp => resp.url().includes('user_settings') && resp.request().method() === 'GET',
+        { timeout: 10000 }
+    )
+    await page.click('#toolbarUserBtn')
+    await expect(page.locator('#toolbarDropdown')).toBeVisible({ timeout: 3000 })
+    await page.click('#settingsBtn')
+    await expect(page.locator('#settingsModal')).toHaveClass(/active/, { timeout: 5000 })
+    await settingsLoaded
+    await page.waitForTimeout(300)
+}
+
+/**
+ * Save and close the settings modal, waiting for the Supabase write to complete.
+ * @param {import('@playwright/test').Page} page
+ */
+export async function saveSettings(page) {
+    const saved = page.waitForResponse(
+        resp => resp.url().includes('user_settings') && resp.request().method() !== 'GET'
+    )
+    await page.click('#saveSettingsBtn')
+    await saved
+    await expect(page.locator('#settingsModal')).not.toHaveClass(/active/, { timeout: 5000 })
+}
+
+/**
+ * Close the settings modal without saving.
+ * @param {import('@playwright/test').Page} page
+ */
+export async function cancelSettings(page) {
+    await page.click('#cancelSettingsModal')
+    await expect(page.locator('#settingsModal')).not.toHaveClass(/active/, { timeout: 5000 })
+}

--- a/tests/e2e/notification-settings.spec.js
+++ b/tests/e2e/notification-settings.spec.js
@@ -1,135 +1,57 @@
 import { test, expect } from './fixtures.js'
+import { waitForApp } from './helpers/todos.js'
+import { openSettingsModal, saveSettings, cancelSettings } from './helpers/settings.js'
 
-/**
- * Helper: open the settings modal.
- */
-async function openSettings(page) {
-    await page.click('#toolbarUserBtn')
-    await page.click('#settingsBtn')
-    await expect(page.locator('#settingsModal')).toBeVisible({ timeout: 5000 })
-}
-
-/**
- * Helper: close the settings modal.
- */
-async function closeSettings(page) {
-    await page.click('#closeSettingsModal')
-    await expect(page.locator('#settingsModal')).not.toBeVisible({ timeout: 5000 })
-}
-
-/**
- * Helper: wait for app to be ready after reload.
- */
-async function waitForApp(page) {
-    await expect(page.locator('#appContainer')).toHaveClass(/active/, { timeout: 30000 })
-    await expect(page.locator('body')).toHaveClass(/fullscreen-mode/, { timeout: 10000 })
-    await page.waitForTimeout(2000)
-}
-
-test.describe('Notification Settings', () => {
-    test('enable notifications shows time and timezone fields', async ({ authedPage }) => {
-        await openSettings(authedPage)
-
-        const checkbox = authedPage.locator('#emailNotificationsEnabled')
-        const detailsSection = authedPage.locator('#notificationSettingsDetails')
-
-        // Ensure notifications are disabled first
-        if (await checkbox.isChecked()) {
-            await checkbox.uncheck()
-            await authedPage.waitForTimeout(500)
-        }
-
-        // Details should be hidden
-        await expect(detailsSection).not.toBeVisible()
-
-        // Enable notifications
-        await checkbox.check()
-        await authedPage.waitForTimeout(500)
-
-        // Time and timezone fields should appear
-        await expect(detailsSection).toBeVisible({ timeout: 3000 })
-        await expect(authedPage.locator('#notificationTime')).toBeVisible()
-        await expect(authedPage.locator('#timezoneSelect')).toBeVisible()
-
-        // Cleanup — disable notifications
-        await checkbox.uncheck()
-        await closeSettings(authedPage)
-    })
-
-    test('disable notifications hides time and timezone fields', async ({ authedPage }) => {
-        await openSettings(authedPage)
-
-        const checkbox = authedPage.locator('#emailNotificationsEnabled')
-
-        // Enable first
-        if (!await checkbox.isChecked()) {
-            await checkbox.check()
-            await authedPage.waitForTimeout(500)
-        }
-
-        // Verify details visible
-        await expect(authedPage.locator('#notificationSettingsDetails')).toBeVisible()
-
-        // Disable notifications
-        await checkbox.uncheck()
-        await authedPage.waitForTimeout(500)
-
-        // Details should be hidden
-        await expect(authedPage.locator('#notificationSettingsDetails')).not.toBeVisible()
-
-        await closeSettings(authedPage)
-    })
-
+test.describe('Notification Settings Persistence', () => {
     test('notification time selection persists after reload', async ({ authedPage }) => {
-        await openSettings(authedPage)
+        await openSettingsModal(authedPage)
 
         const checkbox = authedPage.locator('#emailNotificationsEnabled')
 
-        // Enable notifications
+        // Enable notifications if not already enabled
         if (!await checkbox.isChecked()) {
-            await checkbox.check()
-            await authedPage.waitForTimeout(500)
+            await checkbox.click()
+            await expect(authedPage.locator('#notificationSettingsDetails')).toBeVisible({ timeout: 3000 })
         }
 
         // Select a specific time
         const timeSelect = authedPage.locator('#notificationTime')
         await timeSelect.selectOption('09:00:00')
-        const selectedTime = await timeSelect.inputValue()
-        expect(selectedTime).toBe('09:00:00')
+        expect(await timeSelect.inputValue()).toBe('09:00:00')
 
-        await closeSettings(authedPage)
+        // Save settings
+        await saveSettings(authedPage)
 
         // Reload
         await authedPage.reload()
         await waitForApp(authedPage)
 
-        // Reopen settings and verify
-        await openSettings(authedPage)
-        const timeAfterReload = await authedPage.locator('#notificationTime').inputValue()
-        expect(timeAfterReload).toBe('09:00:00')
+        // Reopen settings and verify time persisted
+        await openSettingsModal(authedPage)
+        expect(await authedPage.locator('#notificationTime').inputValue()).toBe('09:00:00')
 
-        // Cleanup — disable notifications
-        await authedPage.locator('#emailNotificationsEnabled').uncheck()
-        await closeSettings(authedPage)
+        // Cleanup — disable notifications and save
+        await authedPage.locator('#emailNotificationsEnabled').click()
+        await expect(authedPage.locator('#notificationSettingsDetails')).not.toBeVisible({ timeout: 3000 })
+        await saveSettings(authedPage)
     })
 
     test('timezone selection persists after reload', async ({ authedPage }) => {
-        await openSettings(authedPage)
+        await openSettingsModal(authedPage)
 
         const checkbox = authedPage.locator('#emailNotificationsEnabled')
 
-        // Enable notifications
+        // Enable notifications if not already enabled
         if (!await checkbox.isChecked()) {
-            await checkbox.check()
-            await authedPage.waitForTimeout(500)
+            await checkbox.click()
+            await expect(authedPage.locator('#notificationSettingsDetails')).toBeVisible({ timeout: 3000 })
         }
 
-        // Select a timezone
+        // Pick a non-default timezone (use the 3rd option if available)
         const tzSelect = authedPage.locator('#timezoneSelect')
         const options = tzSelect.locator('option')
         const optionCount = await options.count()
 
-        // Pick a non-default timezone (use the 3rd option if available)
         let targetValue
         if (optionCount > 2) {
             targetValue = await options.nth(2).getAttribute('value')
@@ -138,19 +60,20 @@ test.describe('Notification Settings', () => {
             targetValue = await tzSelect.inputValue()
         }
 
-        await closeSettings(authedPage)
+        // Save settings
+        await saveSettings(authedPage)
 
         // Reload
         await authedPage.reload()
         await waitForApp(authedPage)
 
-        // Reopen settings and verify
-        await openSettings(authedPage)
-        const tzAfterReload = await authedPage.locator('#timezoneSelect').inputValue()
-        expect(tzAfterReload).toBe(targetValue)
+        // Reopen settings and verify timezone persisted
+        await openSettingsModal(authedPage)
+        expect(await authedPage.locator('#timezoneSelect').inputValue()).toBe(targetValue)
 
-        // Cleanup — disable notifications
-        await authedPage.locator('#emailNotificationsEnabled').uncheck()
-        await closeSettings(authedPage)
+        // Cleanup — disable notifications and save
+        await authedPage.locator('#emailNotificationsEnabled').click()
+        await expect(authedPage.locator('#notificationSettingsDetails')).not.toBeVisible({ timeout: 3000 })
+        await saveSettings(authedPage)
     })
 })


### PR DESCRIPTION
## Summary
- Adds 2 E2E tests covering notification preference persistence after page reload
- Extracts settings helpers to `tests/e2e/helpers/settings.js`

## New tests in `notification-settings.spec.js`
- **Time persists after reload** — notification time setting saved to database and restored
- **Timezone persists after reload** — timezone setting saved to database and restored

## Shared helper additions (`tests/e2e/helpers/settings.js`)
- `openSettingsModal(page)` — opens settings with Supabase data load wait
- `saveSettings(page)` — saves and closes, waiting for Supabase write
- `cancelSettings(page)` — closes without saving

## Notes
- Toggle enable/disable tests removed — already covered in `user-settings.spec.js`
- Uses `saveSettings` (Save button) instead of close (X) to properly persist changes

## Test plan
- [ ] Both new tests pass in CI
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)