### PR TITLE
fix: Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/css-selector-check.yml
+++ b/.github/workflows/css-selector-check.yml
@@ -13,12 +13,12 @@ jobs:
   check-selectors:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install css-tree jsdom

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,10 +19,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v4
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@v5
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: '.'
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,10 +13,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - run: npx playwright install chromium --with-deps
@@ -24,7 +24,7 @@ jobs:
         env:
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary
- Bump all GitHub Actions (`checkout`, `setup-node`, `upload-artifact`, `configure-pages`, `upload-pages-artifact`, `deploy-pages`) to their latest major versions (v5/v4) to resolve the Node.js 20 deprecation warning
- Update `node-version` from `20` to `22` (current LTS) in `css-selector-check` and `e2e-tests` workflows

## Affected workflows
- `auto-version-bump.yml`
- `css-selector-check.yml`
- `deploy-pages.yml`
- `e2e-tests.yml`

## Test plan
- [ ] Verify `css-selector-check` workflow passes on this PR
- [ ] Verify `e2e-tests` workflow passes on this PR
- [ ] After merge, verify `deploy-pages` and `auto-version-bump` run without Node.js 20 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)