### PR TITLE
fix: Fix recurrence validation and monthly date overflow bugs

### DIFF
--- a/src/utils/recurrence.js
+++ b/src/utils/recurrence.js
@@ -132,6 +132,8 @@ export function calculateNextOccurrence(rule, fromDate) {
             let next = new Date(current)
 
             // Move to next interval month
+            // Set day to 1 first to avoid month overflow (e.g., Jan 31 + 1 month → Mar 3)
+            next.setDate(1)
             next.setMonth(next.getMonth() + interval)
 
             if (dayType === 'day_of_month') {
@@ -333,7 +335,7 @@ export function validateRecurrenceRule(rule) {
         if (rule.dayType && !['day_of_month', 'weekday', 'last_day'].includes(rule.dayType)) {
             return { valid: false, error: 'Invalid day type' }
         }
-        if (rule.dayOfMonth && (rule.dayOfMonth < 1 || rule.dayOfMonth > 31)) {
+        if (rule.dayOfMonth !== undefined && (rule.dayOfMonth < 1 || rule.dayOfMonth > 31)) {
             return { valid: false, error: 'Day of month must be between 1 and 31' }
         }
         if (rule.weekday !== undefined && (rule.weekday < 0 || rule.weekday > 6)) {
@@ -345,7 +347,7 @@ export function validateRecurrenceRule(rule) {
     }
 
     if (rule.type === 'yearly') {
-        if (rule.month && (rule.month < 1 || rule.month > 12)) {
+        if (rule.month !== undefined && (rule.month < 1 || rule.month > 12)) {
             return { valid: false, error: 'Month must be between 1 and 12' }
         }
     }

--- a/tests/unit/recurrence.test.js
+++ b/tests/unit/recurrence.test.js
@@ -142,17 +142,21 @@ describe('calculateNextOccurrence', () => {
         })
 
         it('clamps day when target month is shorter', () => {
-            // BUG: setMonth() on Jan 31 overflows to March because Feb doesn't
-            // have 31 days. The function then operates on March instead of Feb.
-            // Starting from a date that won't overflow works correctly:
             expect(calculateNextOccurrence(
                 { type: 'monthly', interval: 1, dayType: 'day_of_month', dayOfMonth: 31 },
                 '2025-02-28'
             )).toBe('2025-03-31')
         })
 
+        it('clamps day 31 from Jan to Feb (Feb has 28 days)', () => {
+            // Previously this overflowed: Jan 31 + setMonth(1) → Mar 3
+            expect(calculateNextOccurrence(
+                { type: 'monthly', interval: 1, dayType: 'day_of_month', dayOfMonth: 31 },
+                '2025-01-31'
+            )).toBe('2025-02-28')
+        })
+
         it('handles month with fewer days (from day 15)', () => {
-            // When starting day doesn't cause setMonth overflow, clamping works
             expect(calculateNextOccurrence(
                 { type: 'monthly', interval: 1, dayType: 'day_of_month', dayOfMonth: 30 },
                 '2025-01-15'
@@ -185,11 +189,10 @@ describe('calculateNextOccurrence', () => {
         })
 
         it('computes last day of month', () => {
-            // Start from a non-overflowing date to avoid JS Date setMonth bug
             expect(calculateNextOccurrence(
                 { type: 'monthly', interval: 1, dayType: 'last_day' },
-                '2025-02-28'
-            )).toBe('2025-03-31')
+                '2025-01-31'
+            )).toBe('2025-02-28')
         })
 
         it('last day works across months with same length', () => {
@@ -547,11 +550,9 @@ describe('validateRecurrenceRule', () => {
                 .toEqual({ valid: false, error: 'Day of month must be between 1 and 31' })
         })
 
-        it('does not reject dayOfMonth 0 due to falsy check (known gap)', () => {
-            // BUG: The validation uses `rule.dayOfMonth && (...)` which
-            // treats 0 as falsy and skips the range check entirely.
+        it('rejects dayOfMonth 0 as out of range', () => {
             expect(validateRecurrenceRule({ type: 'monthly', interval: 1, dayOfMonth: 0 }))
-                .toEqual({ valid: true })
+                .toEqual({ valid: false, error: 'Day of month must be between 1 and 31' })
         })
 
         it('rejects weekday > 6', () => {
@@ -574,10 +575,9 @@ describe('validateRecurrenceRule', () => {
                 .toEqual({ valid: false, error: 'Month must be between 1 and 12' })
         })
 
-        it('does not reject month 0 due to falsy check (known gap)', () => {
-            // BUG: Same falsy issue — `rule.month && (...)` skips check when month is 0.
+        it('rejects month 0 as out of range', () => {
             expect(validateRecurrenceRule({ type: 'yearly', interval: 1, month: 0 }))
-                .toEqual({ valid: true })
+                .toEqual({ valid: false, error: 'Month must be between 1 and 12' })
         })
 
         it('accepts valid yearly rule', () => {


### PR DESCRIPTION
## Summary
- **Fix monthly `setMonth()` overflow**: Setting day to 1 before changing month prevents Jan 31 + 1 month from overflowing to March 3 instead of Feb 28
- **Fix falsy-zero validation for `dayOfMonth`**: `rule.dayOfMonth !== undefined` replaces `rule.dayOfMonth &&` so that `0` is properly rejected as invalid
- **Fix falsy-zero validation for `month`**: Same pattern — `0` is now correctly rejected as out of range (months are 1-12)

All three bugs were discovered by the unit tests added in PR #431.

## Test plan
- [x] All 138 unit tests pass (including updated assertions for the fixed bugs)
- [ ] CI passes (check-selectors + E2E tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)