### PR TITLE
ci: Add GitHub Actions workflow for Vitest unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,22 @@
+name: Unit Tests
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+
+concurrency:
+  group: unit-tests-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test:unit


### PR DESCRIPTION
## Summary
- Adds a new CI workflow that runs Vitest unit tests on every PR to main
- Follows the same conventions as the existing E2E and CSS selector check workflows (concurrency, Node 22, npm cache)
- No secrets or browser installation needed — unit tests run in Node.js only

## Test plan
- [ ] CI passes on this PR (the new workflow should run and pass itself)
- [ ] Verify unit-test job appears in PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)