### PR TITLE
fix: Downgrade actions/deploy-pages to v4 (v5 does not exist)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,5 +24,5 @@ jobs:
       - uses: actions/upload-pages-artifact@v4
         with:
           path: '.'
-      - uses: actions/deploy-pages@v5
+      - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
## Summary
- `actions/deploy-pages` was bumped to `v5` in PR #430, but **v5 doesn't exist** — latest is v4
- This has been breaking all GitHub Pages deployments since that merge (5 consecutive failures)
- One-character fix: `v5` → `v4`

## Test plan
- [ ] CI passes
- [ ] After merge, deploy-pages workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)