### PR TITLE
fix: Make daily-quotes E2E tests resilient to parallel interference

### DIFF
--- a/tests/e2e/daily-quotes.spec.js
+++ b/tests/e2e/daily-quotes.spec.js
@@ -1,15 +1,12 @@
 import { test, expect } from './fixtures.js'
-import { unique, addTodo, todoItem, deleteTodo, switchGtdTab, clearInboxViaApi, restoreInboxViaApi } from './helpers/todos.js'
+import { unique, addTodo, todoItem, deleteTodo, clearInboxViaApi, restoreInboxViaApi } from './helpers/todos.js'
 
 test.describe('Daily Quotes (Empty Inbox)', () => {
     test('empty Inbox shows a motivational quote', async ({ authedPage }) => {
         const page = authedPage
 
-        // Bulk-move all inbox todos out of the way via API (much faster than UI deletion)
+        // clearInboxViaApi retries until inbox is truly empty (handles parallel test interference)
         const movedIds = await clearInboxViaApi(page)
-
-        // Ensure we are on the Inbox tab
-        await switchGtdTab(page, 'inbox')
 
         // The zen state with quote should now be visible
         await expect(page.locator('.inbox-zen-state')).toBeVisible({ timeout: 10000 })
@@ -30,7 +27,6 @@ test.describe('Daily Quotes (Empty Inbox)', () => {
         const page = authedPage
 
         const movedIds = await clearInboxViaApi(page)
-        await switchGtdTab(page, 'inbox')
 
         // Wait for zen state and quote to load
         await expect(page.locator('.inbox-zen-state')).toBeVisible({ timeout: 10000 })
@@ -57,7 +53,6 @@ test.describe('Daily Quotes (Empty Inbox)', () => {
         const page = authedPage
 
         const movedIds = await clearInboxViaApi(page)
-        await switchGtdTab(page, 'inbox')
 
         // Verify zen state with quote is visible
         await expect(page.locator('.inbox-zen-state')).toBeVisible({ timeout: 10000 })
@@ -82,7 +77,6 @@ test.describe('Daily Quotes (Empty Inbox)', () => {
         const page = authedPage
 
         const movedIds = await clearInboxViaApi(page)
-        await switchGtdTab(page, 'inbox')
 
         // Verify zen state is visible initially (empty inbox)
         await expect(page.locator('.inbox-zen-state')).toBeVisible({ timeout: 10000 })

--- a/tests/e2e/helpers/todos.js
+++ b/tests/e2e/helpers/todos.js
@@ -111,53 +111,69 @@ export async function switchGtdTab(page, status) {
  * @returns {Promise<string[]>} IDs of todos that were moved
  */
 export async function clearInboxViaApi(page) {
-    const movedIds = await page.evaluate(async () => {
-        const SUPABASE_URL = 'https://rkvmujdayjmszmyzbhal.supabase.co'
-        const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJrdm11amRheWptc3pteXpiaGFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQxODc2MDcsImV4cCI6MjA3OTc2MzYwN30.55RoV1mmHeykVz9waU7Jz6-JSkrRqlNa-ABBE8SN-jA'
+    const allMovedIds = []
 
-        // Get the session token from localStorage (Supabase v2 uses 'sb-<ref>-auth-token' key)
-        const storageKey = Object.keys(localStorage).find(k => k.startsWith('sb-') && k.endsWith('-auth-token'))
-        if (!storageKey) throw new Error('No Supabase auth session found in localStorage')
-        const session = JSON.parse(localStorage.getItem(storageKey))
-        const token = session?.access_token || session?.currentSession?.access_token
+    // Retry clearing up to 3 times — other parallel test groups may add
+    // inbox todos between our API clear and the page reload.
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const movedIds = await page.evaluate(async () => {
+            const SUPABASE_URL = 'https://rkvmujdayjmszmyzbhal.supabase.co'
+            const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJrdm11amRheWptc3pteXpiaGFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQxODc2MDcsImV4cCI6MjA3OTc2MzYwN30.55RoV1mmHeykVz9waU7Jz6-JSkrRqlNa-ABBE8SN-jA'
 
-        // Fetch all inbox todo IDs
-        const listResp = await fetch(
-            `${SUPABASE_URL}/rest/v1/todos?gtd_status=eq.inbox&select=id`,
-            {
-                headers: {
-                    'apikey': SUPABASE_KEY,
-                    'Authorization': `Bearer ${token}`
+            // Get the session token from localStorage (Supabase v2 uses 'sb-<ref>-auth-token' key)
+            const storageKey = Object.keys(localStorage).find(k => k.startsWith('sb-') && k.endsWith('-auth-token'))
+            if (!storageKey) throw new Error('No Supabase auth session found in localStorage')
+            const session = JSON.parse(localStorage.getItem(storageKey))
+            const token = session?.access_token || session?.currentSession?.access_token
+
+            // Fetch all inbox todo IDs
+            const listResp = await fetch(
+                `${SUPABASE_URL}/rest/v1/todos?gtd_status=eq.inbox&select=id`,
+                {
+                    headers: {
+                        'apikey': SUPABASE_KEY,
+                        'Authorization': `Bearer ${token}`
+                    }
                 }
-            }
-        )
-        const inboxTodos = await listResp.json()
-        if (!inboxTodos.length) return []
+            )
+            const inboxTodos = await listResp.json()
+            if (!inboxTodos.length) return []
 
-        const ids = inboxTodos.map(t => t.id)
+            const ids = inboxTodos.map(t => t.id)
 
-        // Bulk-update all inbox todos to someday_maybe
-        await fetch(
-            `${SUPABASE_URL}/rest/v1/todos?gtd_status=eq.inbox`,
-            {
-                method: 'PATCH',
-                headers: {
-                    'apikey': SUPABASE_KEY,
-                    'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json',
-                    'Prefer': 'return=minimal'
-                },
-                body: JSON.stringify({ gtd_status: 'someday_maybe' })
-            }
-        )
+            // Bulk-update all inbox todos to someday_maybe
+            await fetch(
+                `${SUPABASE_URL}/rest/v1/todos?gtd_status=eq.inbox`,
+                {
+                    method: 'PATCH',
+                    headers: {
+                        'apikey': SUPABASE_KEY,
+                        'Authorization': `Bearer ${token}`,
+                        'Content-Type': 'application/json',
+                        'Prefer': 'return=minimal'
+                    },
+                    body: JSON.stringify({ gtd_status: 'someday_maybe' })
+                }
+            )
 
-        return ids
-    })
+            return ids
+        })
 
-    // Reload app to pick up the changes
-    await page.reload()
-    await waitForApp(page)
-    return movedIds
+        allMovedIds.push(...movedIds)
+
+        // Reload app to pick up the changes
+        await page.reload()
+        await waitForApp(page)
+
+        // Switch to inbox and verify it's actually empty
+        await page.click('.gtd-tab.inbox')
+        await expect(page.locator('.gtd-tab.inbox')).toHaveClass(/active/, { timeout: 3000 })
+
+        const remainingCount = await page.locator('.todo-item').count()
+        if (remainingCount === 0) break
+    }
+
+    return allMovedIds
 }
 
 /**


### PR DESCRIPTION
## Summary
- `clearInboxViaApi()` now retries up to 3 times, re-clearing inbox after each reload to handle concurrent modifications from other parallel test groups
- After each clear, verifies inbox is actually empty on the page before proceeding
- Removed redundant `switchGtdTab(page, 'inbox')` calls from `daily-quotes.spec.js` since `clearInboxViaApi()` now handles the tab switch and verification

## Root cause
When E2E tests run in 8 parallel groups, all groups share the same Supabase test account. The `daily-quotes` tests need an empty inbox, but other groups (e.g. `todos`, `navigation`) may add inbox items concurrently. The previous single-shot clear was a race condition.

## Test plan
- [x] `clearInboxViaApi()` retries until inbox count is 0 or 3 attempts exhausted
- [x] All moved IDs tracked across retries for proper restoration
- [x] Tests simplified — no duplicate tab switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)