### PR TITLE
test: Add coverage config and shared Supabase mock helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "check:css": "node scripts/check-css-selectors.js",
     "test": "npx playwright test",
     "test:unit": "vitest run",
+    "test:unit:coverage": "vitest run --coverage",
     "test:unit:watch": "vitest",
     "test:headed": "npx playwright test --headed",
     "prepare": "node scripts/setup-hooks.js"

--- a/tests/unit/helpers/supabase-mock.js
+++ b/tests/unit/helpers/supabase-mock.js
@@ -1,0 +1,68 @@
+import { vi } from 'vitest'
+
+/**
+ * Creates a chainable Supabase client mock with a result queue.
+ *
+ * The mock supports all common Supabase query-builder methods (from, select,
+ * insert, update, delete, upsert, eq, neq, in, order, range, single) and
+ * resolves via a custom `.then()` that pops results from an internal queue.
+ *
+ * Usage:
+ *   import { createSupabaseMock } from '../helpers/supabase-mock.js'
+ *
+ *   const mockSupabase = createSupabaseMock()
+ *
+ *   vi.mock('../../src/core/supabase.js', () => ({
+ *       supabase: mockSupabase
+ *   }))
+ *
+ *   // In beforeEach:
+ *   mockSupabase._reset()
+ *
+ *   // Before each supabase call in a test, queue the expected result:
+ *   mockSupabase._queueResult([{ id: '1', text: 'Hello' }])        // success
+ *   mockSupabase._queueResult(null, { message: 'DB error' })       // error
+ *
+ * @returns {object} A chainable mock object with `_queueResult()` and `_reset()` helpers.
+ */
+export function createSupabaseMock() {
+    const results = []
+    let callIndex = 0
+
+    const chain = {
+        from: vi.fn(() => chain),
+        select: vi.fn(() => chain),
+        insert: vi.fn(() => chain),
+        update: vi.fn(() => chain),
+        delete: vi.fn(() => chain),
+        upsert: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        in: vi.fn(() => chain),
+        order: vi.fn(() => chain),
+        range: vi.fn(() => chain),
+        single: vi.fn(() => chain),
+        then: vi.fn((resolve) => {
+            const result = results[callIndex] || { data: null, error: null }
+            callIndex++
+            resolve(result)
+        }),
+
+        /**
+         * Enqueue a result that the next awaited Supabase call will resolve with.
+         * @param {*} data - The data property of the response.
+         * @param {object|null} [error=null] - The error property of the response.
+         */
+        _queueResult(data, error = null) {
+            results.push({ data, error })
+        },
+
+        /** Clear all queued results and reset the call index. */
+        _reset() {
+            results.length = 0
+            callIndex = 0
+        }
+    }
+
+    return chain
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,6 +3,11 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
     test: {
         include: ['tests/unit/**/*.test.js'],
-        environment: 'node'
+        environment: 'node',
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.js'],
+            exclude: ['src/ui/**']
+        }
     }
 })


### PR DESCRIPTION
## Summary

- **Coverage configuration**: Added v8 coverage provider to `vitest.config.js` with `include: ['src/**/*.js']` and `exclude: ['src/ui/**']` (UI components are covered by E2E tests). Added `test:unit:coverage` npm script. No coverage thresholds set yet — run the report first to establish baselines.
- **Shared Supabase mock helper**: Created `tests/unit/helpers/supabase-mock.js` exporting a reusable `createSupabaseMock()` factory with queue-based result management (`_queueResult`, `_reset`). This consolidates the pattern duplicated across 4+ test files. Existing tests are **not** modified — the helper is available for new tests going forward.

## Test plan

- [x] `npm run test:unit` — all 854 tests pass with no changes
- [ ] `npm run test:unit:coverage` — verify coverage report generates correctly
- [ ] Verify new test files can import from `tests/unit/helpers/supabase-mock.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)