### PR TITLE
fix(security): throw when encrypt() called without encryption key

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -196,7 +196,9 @@ export function onAuthStateChange(onSignOut) {
  */
 export async function encrypt(plaintext) {
     const encryptionKey = store.get('encryptionKey')
-    if (!encryptionKey) return plaintext
+    if (!encryptionKey) {
+        throw new Error('Encryption key not available. Please log out and log in again.')
+    }
     return await CryptoUtils.encrypt(plaintext, encryptionKey)
 }
 

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -539,12 +539,12 @@ describe('auth', () => {
             expect(CryptoUtils.encrypt).toHaveBeenCalledWith('hello', 'mock-key')
         })
 
-        it('returns plaintext when no encryptionKey (passthrough)', async () => {
+        it('throws when no encryptionKey is available', async () => {
             // No encryptionKey set
 
-            const result = await encrypt('hello')
-
-            expect(result).toBe('hello')
+            await expect(encrypt('hello')).rejects.toThrow(
+                'Encryption key not available. Please log out and log in again.'
+            )
             expect(CryptoUtils.encrypt).not.toHaveBeenCalled()
         })
     })


### PR DESCRIPTION
## Summary
- `encrypt()` previously returned plaintext silently when no encryption key was available
- Data the user believed was encrypted could be stored in cleartext in Supabase
- Now throws an explicit error, ensuring callers handle the missing key scenario visibly

## Test plan
- [ ] Verify normal encryption works after login
- [ ] Verify that if encryption key is somehow missing, user sees a clear error message
- [ ] Verify no silent plaintext storage occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)