### PR TITLE
fix(security): throw on decryption failure for encrypted data

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -210,13 +210,15 @@ export async function encrypt(plaintext) {
 export async function decrypt(ciphertext) {
     const encryptionKey = store.get('encryptionKey')
     if (!encryptionKey) return ciphertext
-    // Check if this looks like encrypted data (base64 with minimum length for IV + data)
     if (!ciphertext || ciphertext.length < 20) return ciphertext
     try {
         return await CryptoUtils.decrypt(ciphertext, encryptionKey)
     } catch (e) {
-        // If decryption fails, return original (might be unencrypted legacy data)
-        console.warn('Decryption failed, returning original text:', e)
+        const looksEncrypted = /^[A-Za-z0-9+/]+=*$/.test(ciphertext) && ciphertext.length >= 32
+        if (looksEncrypted) {
+            console.error('Decryption failed for data that appears encrypted:', e)
+            throw new Error('Failed to decrypt data. Your encryption key may be incorrect.')
+        }
         return ciphertext
     }
 }

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -584,16 +584,26 @@ describe('auth', () => {
             expect(CryptoUtils.decrypt).not.toHaveBeenCalled()
         })
 
-        it('returns original text when decryption throws (legacy data)', async () => {
+        it('returns original text when decryption throws for non-encrypted-looking data (legacy data)', async () => {
             store.set('encryptionKey', 'mock-key')
             CryptoUtils.decrypt.mockRejectedValueOnce(new Error('bad data'))
-            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
             const result = await decrypt('this-is-long-enough-to-try-decrypt')
 
             expect(result).toBe('this-is-long-enough-to-try-decrypt')
-            expect(warnSpy).toHaveBeenCalled()
-            warnSpy.mockRestore()
+        })
+
+        it('throws error when decryption fails for encrypted-looking data', async () => {
+            store.set('encryptionKey', 'mock-key')
+            CryptoUtils.decrypt.mockRejectedValueOnce(new Error('bad data'))
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+            // Base64-looking string with length >= 32
+            const encryptedLooking = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
+            await expect(decrypt(encryptedLooking)).rejects.toThrow('Failed to decrypt data. Your encryption key may be incorrect.')
+            expect(errorSpy).toHaveBeenCalled()
+            errorSpy.mockRestore()
         })
     })
 })


### PR DESCRIPTION
## Summary
- Previously `decrypt()` silently returned raw ciphertext on failure, risking permanent data loss if the user edited the item (ciphertext gets re-encrypted)
- Now distinguishes between legacy unencrypted data (safe fallback) and genuine decryption failures (throws error)
- Prevents silent data corruption from wrong encryption keys or corrupted data

## Test plan
- [ ] Verify normal encrypted data decrypts correctly
- [ ] Verify legacy unencrypted data still loads without errors
- [ ] Verify that wrong encryption key produces a visible error instead of garbled ciphertext

🤖 Generated with [Claude Code](https://claude.com/claude-code)