### PR TITLE
fix(security): check error when loading encryption salt

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -11,11 +11,15 @@ import { CryptoUtils } from '../utils/crypto.js'
  */
 export async function initializeEncryption(user, password) {
     // Try to load existing salt from user_settings
-    const { data: settings } = await supabase
+    const { data: settings, error: settingsError } = await supabase
         .from('user_settings')
         .select('encryption_salt')
         .eq('user_id', user.id)
         .single()
+
+    if (settingsError && settingsError.code !== 'PGRST116') {
+        throw new Error('Failed to load encryption settings: ' + settingsError.message)
+    }
 
     let salt
     if (settings && settings.encryption_salt) {


### PR DESCRIPTION
## Summary
- `initializeEncryption()` silently discarded Supabase query errors when loading the encryption salt
- A transient network error could cause a new random salt to be generated, deriving a completely different encryption key
- This made all previously encrypted data permanently unreadable, with no warning to the user
- Now properly checks the error and throws on failure (PGRST116 "no rows" is expected for new users)

## Test plan
- [ ] Verify existing users can log in and decrypt data normally
- [ ] Verify new users get a fresh salt generated correctly
- [ ] Verify that a Supabase query failure during login shows an error instead of silently generating a new salt

🤖 Generated with [Claude Code](https://claude.com/claude-code)