### PR TITLE
fix(security): check errors in descendant area propagation

### DIFF
--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -352,10 +352,15 @@ export async function updateProject(projectId, updates) {
         const descendantIds = getDescendantIds(projectId)
         if (descendantIds.length > 0) {
             for (const childId of descendantIds) {
-                await supabase
+                const { error: childError } = await supabase
                     .from('projects')
                     .update({ area_id: updates.area_id })
                     .eq('id', childId)
+
+                if (childError) {
+                    console.error('Error propagating area to descendant project:', childError)
+                    throw childError
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- When updating a project's area, the change propagates to all descendant projects
- The Supabase calls in the propagation loop never checked for errors
- Partial failures left the project hierarchy in an inconsistent area state
- Now checks each update and throws on error

## Test plan
- [ ] Verify changing a parent project's area propagates to children
- [ ] Verify that a database error during propagation surfaces visibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)