### PR TITLE
fix(security): check database errors in reorder operations

### DIFF
--- a/src/services/areas.js
+++ b/src/services/areas.js
@@ -165,10 +165,15 @@ export async function reorderAreas(orderedIds) {
 
     // Update database
     for (let i = 0; i < orderedIds.length; i++) {
-        await supabase
+        const { error } = await supabase
             .from('areas')
             .update({ sort_order: i })
             .eq('id', orderedIds[i])
+
+        if (error) {
+            console.error('Error updating area sort order:', error)
+            throw error
+        }
     }
 
     events.emit(Events.AREAS_LOADED, store.get('areas'))

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -552,10 +552,15 @@ export async function reorderProjects(orderedIds) {
 
     // Update database
     for (let i = 0; i < orderedIds.length; i++) {
-        await supabase
+        const { error } = await supabase
             .from('projects')
             .update({ sort_order: i })
             .eq('id', orderedIds[i])
+
+        if (error) {
+            console.error('Error updating project sort order:', error)
+            throw error
+        }
     }
 
     events.emit(Events.PROJECTS_LOADED, store.get('projects'))


### PR DESCRIPTION
## Summary
- `reorderProjects()` and `reorderAreas()` both update local state optimistically, then loop through Supabase updates
- Neither checked the error from the database calls — silent failures caused state divergence
- Now both functions check and throw on database errors

## Test plan
- [ ] Verify drag-and-drop reordering of projects works correctly
- [ ] Verify drag-and-drop reordering of areas works correctly
- [ ] Verify that a database error during reorder surfaces visibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)