### PR TITLE
fix(security): throw on encryption salt save failure

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -40,7 +40,7 @@ export async function initializeEncryption(user, password) {
             }, { onConflict: 'user_id' })
 
         if (updateError) {
-            console.error('Error saving encryption salt:', updateError)
+            throw new Error('Failed to save encryption salt: ' + updateError.message)
         }
     }
 


### PR DESCRIPTION
## Summary
- When a new user signs up, a random encryption salt is generated and saved to `user_settings`
- Previously, if this save failed, execution continued with an ephemeral salt
- On next login, the salt wouldn't be found, a new one generated, and all previously encrypted data permanently lost
- Now throws an error to prevent proceeding with an unsaved salt

## Test plan
- [ ] Verify new user signup and first login work correctly
- [ ] Verify that a database write failure during salt save shows an error
- [ ] Verify the user cannot proceed to encrypt data if the salt wasn't saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)