### PR TITLE
fix(security): check database errors in bulk undo operations

### DIFF
--- a/src/services/todos-bulk.js
+++ b/src/services/todos-bulk.js
@@ -244,10 +244,15 @@ async function bulkRestorePreviousStates(previousStates, fields) {
             }
         }
 
-        await supabase
+        const { error } = await supabase
             .from('todos')
             .update(updateData)
             .eq('id', prev.id)
+
+        if (error) {
+            console.error('Error restoring previous todo state:', error)
+            throw error
+        }
     }
 
     // Update local state


### PR DESCRIPTION
## Summary
- `bulkRestorePreviousStates()` is the undo handler for bulk status/project/priority changes
- The Supabase update calls in the loop never checked for errors
- A failed update would leave the database in one state and the UI in another
- Now checks each update and throws on error

## Test plan
- [ ] Verify bulk status change + undo works correctly
- [ ] Verify that a database error during undo surfaces visibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)