### PR TITLE
fix(security): check errors when updating recurrence count

### DIFF
--- a/src/services/todos-recurrence.js
+++ b/src/services/todos-recurrence.js
@@ -76,10 +76,15 @@ export async function createRecurringTodo(todoData, recurrenceRule, endCondition
     }
 
     // Update template recurrence count
-    await supabase
+    const { error: countError } = await supabase
         .from('todos')
         .update({ recurrence_count: 1 })
         .eq('id', template.id)
+
+    if (countError) {
+        console.error('Error updating recurrence count:', countError)
+        throw countError
+    }
 
     // Add instance to local state
     const instance = { ...instanceData[0], text, comment }
@@ -177,10 +182,15 @@ export async function generateNextRecurrence(templateId, fromDate) {
     }
 
     // Update template recurrence count
-    await supabase
+    const { error: countError } = await supabase
         .from('todos')
         .update({ recurrence_count: newCount })
         .eq('id', template.id)
+
+    if (countError) {
+        console.error('Error updating recurrence count:', countError)
+        throw countError
+    }
 
     // Update template in store
     template.recurrence_count = newCount


### PR DESCRIPTION
## Summary
- `createRecurringTodo()` and `generateNextRecurrence()` both update the template's recurrence count
- Neither checked the error from the Supabase update
- A failed count update could cause the recurrence to exceed its configured end limit
- Now both locations check and throw on error

## Test plan
- [ ] Verify creating a recurring todo works correctly
- [ ] Verify completing a recurring instance generates the next one with correct count
- [ ] Verify recurrence stops correctly after reaching the configured count limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)