### PR TITLE
fix(security): log errors in session recovery catch block

### DIFF
--- a/app.js
+++ b/app.js
@@ -387,7 +387,9 @@ class TodoApp {
                         setTimeout(() => { this._suppressSignOut = false }, 2000)
                         return
                     }
-                } catch { /* recovery failed, fall through to sign out */ }
+                } catch (recoveryError) {
+                    console.error('Session recovery failed:', recoveryError)
+                }
                 this._suppressSignOut = false
             }
 


### PR DESCRIPTION
## Summary
- The session recovery path in `onAuthStateChange` had a bare `catch {}` — the only empty catch block in the codebase
- Silently swallowed all errors from `signInWithPassword` including network failures and rate limiting
- Now logs the error for debugging while still falling through to sign-out

## Test plan
- [ ] Verify normal session recovery still works
- [ ] Verify failed recovery errors appear in console
- [ ] Verify user is signed out normally after failed recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)