### PR TITLE
fix(security): handle data loading failures in handleAuthSuccess

### DIFF
--- a/app.js
+++ b/app.js
@@ -755,14 +755,21 @@ class TodoApp {
         document.body.classList.add('fullscreen-mode')
 
         // Load all data
-        await Promise.all([
-            loadAreas(),
-            loadCategories(),
-            loadPriorities(),
-            loadContexts(),
-            loadProjects(),
-            loadTodos()
-        ])
+        try {
+            await Promise.all([
+                loadAreas(),
+                loadCategories(),
+                loadPriorities(),
+                loadContexts(),
+                loadProjects(),
+                loadTodos()
+            ])
+        } catch (error) {
+            console.error('Failed to load application data:', error)
+            this.showMessage('Failed to load your data. Please refresh the page.', 'error')
+            this.hideLoadingScreen()
+            return
+        }
 
         // Restore persisted UI state
         restoreSelectedArea()


### PR DESCRIPTION
## Summary
- `handleAuthSuccess()` called `Promise.all` for six data loading functions without error handling
- If any loader threw (network error, session expired, decryption failure), the loading screen stayed visible with no feedback
- Now wraps in try-catch and shows a user-visible error message

## Test plan
- [ ] Verify normal login loads all data correctly
- [ ] Verify that a data loading failure shows an error message instead of a stuck loading screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)