### PR TITLE
fix(security): add .catch() to fire-and-forget async calls

### DIFF
--- a/app.js
+++ b/app.js
@@ -780,10 +780,10 @@ class TodoApp {
         initNavigation()
 
         // Load non-essential items without waiting
-        loadThemeFromDatabase()
-        loadDensityFromDatabase()
-        this.loadUserSettingsDisplay()
-        loadProjectTemplates()
+        loadThemeFromDatabase().catch(e => console.error('Failed to load theme:', e))
+        loadDensityFromDatabase().catch(e => console.error('Failed to load density:', e))
+        this.loadUserSettingsDisplay().catch(e => console.error('Failed to load user settings:', e))
+        loadProjectTemplates().catch(e => console.error('Failed to load templates:', e))
 
         this.hideLoadingScreen()
     }


### PR DESCRIPTION
## Summary
- Four async functions in `handleAuthSuccess` were called without `await` or `.catch()`
- Unhandled promise rejections could silently crash the page in some browsers
- Now each call has a `.catch()` handler that logs errors

## Test plan
- [ ] Verify login still loads theme, density, settings, and templates
- [ ] Verify that a failure in non-essential loading doesn't crash the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)