### PR TITLE
fix(security): show user-visible errors in modal add handlers

### DIFF
--- a/app.js
+++ b/app.js
@@ -973,6 +973,7 @@ class TodoApp {
             renderManageProjectsList(this.manageProjectsList)
         } catch (error) {
             console.error('Failed to add project:', error)
+            alert('Failed to add project')
         } finally {
             this.addNewProjectBtn.disabled = false
             this.addNewProjectBtn.textContent = 'Add'
@@ -992,6 +993,7 @@ class TodoApp {
             renderTemplatesList(this.templatesList)
         } catch (error) {
             console.error('Failed to add template:', error)
+            alert('Failed to add template')
         } finally {
             this.addTemplateBtn.disabled = false
             this.addTemplateBtn.textContent = 'Add'


### PR DESCRIPTION
## Summary
- `handleAddProjectInModal()` and `handleAddTemplate()` caught errors but only logged to console
- The user saw the button go from "Adding..." back to "Add" with no indication of failure
- Now shows `alert()` on error, matching the pattern used in `handleAddProject()`

## Test plan
- [ ] Verify adding a project in the manage modal works and shows error on failure
- [ ] Verify adding a template works and shows error on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)