### PR TITLE
fix(security): check and throw on getSession() errors

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -205,7 +205,11 @@ export function lock() {
  * @returns {Promise<{session: Object|null, user: Object|null}>}
  */
 export async function getSession() {
-    const { data: { session } } = await supabase.auth.getSession()
+    const { data: { session }, error } = await supabase.auth.getSession()
+    if (error) {
+        console.error('Failed to retrieve session:', error)
+        throw error
+    }
     return { session, user: session?.user || null }
 }
 


### PR DESCRIPTION
## Summary
- `getSession()` ignored the error from `supabase.auth.getSession()`
- A Supabase error (invalid JWT, network failure) returned null session
- This was indistinguishable from "user not logged in", silently logging out users with valid sessions
- Now checks and throws on error

## Test plan
- [ ] Verify normal session retrieval works
- [ ] Verify that a transient network error during session check doesn't silently log out the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)