### PR TITLE
fix(security): check signOut error in logout()

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -136,7 +136,10 @@ export async function signup(email, password) {
  * Logout current user
  */
 export async function logout() {
-    await supabase.auth.signOut()
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+        console.error('Error during sign out:', error)
+    }
     sessionStorage.removeItem('_ep')
     // Clear persisted UI state
     localStorage.removeItem('selectedAreaId')


### PR DESCRIPTION
## Summary
- `logout()` never checked the return value of `supabase.auth.signOut()`
- If sign-out failed (network error), local state was cleared but the server session remained valid
- The session JWT could be reused if intercepted
- Now checks and logs the error

## Test plan
- [ ] Verify logout works normally
- [ ] Verify that a network error during sign-out is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)