### PR TITLE
fix(security): add import size limit of 500 items

### DIFF
--- a/src/ui/modals/ImportModal.js
+++ b/src/ui/modals/ImportModal.js
@@ -93,6 +93,12 @@ export class ImportModal extends BaseModal {
 
         if (lines.length === 0) return
 
+        const MAX_IMPORT_LINES = 500
+        if (lines.length > MAX_IMPORT_LINES) {
+            alert(`Cannot import more than ${MAX_IMPORT_LINES} items at once. You have ${lines.length} lines.`)
+            return
+        }
+
         // Get shared settings
         const projectId = this.projectSelect.value || null
         const categoryId = this.categorySelect.value || null


### PR DESCRIPTION
## Summary
- Import modal accepted unlimited text input with no line count limit
- Extremely large imports could crash the browser or leave partial data
- Now limits imports to 500 items with a clear error message

## Test plan
- [ ] Verify importing < 500 lines works normally
- [ ] Verify importing > 500 lines shows an error and prevents the import

🤖 Generated with [Claude Code](https://claude.com/claude-code)