### PR TITLE
fix(security): log partial failure risk in deleteProject

### DIFF
--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -238,14 +238,20 @@ export async function deleteProject(projectId, { deleteTodos = false, moveToProj
         store.set('todos', todos)
     }
 
-    const { error } = await supabase
-        .from('projects')
-        .delete()
-        .eq('id', projectId)
+    let deleteError
+    try {
+        const { error } = await supabase
+            .from('projects')
+            .delete()
+            .eq('id', projectId)
+        deleteError = error
+    } catch (e) {
+        deleteError = e
+    }
 
-    if (error) {
-        console.error('Error deleting project:', error)
-        throw error
+    if (deleteError) {
+        console.error('Error deleting project (todos may have already been moved/deleted):', deleteError)
+        throw deleteError
     }
 
     // Remove project and all descendants from local store


### PR DESCRIPTION
## Summary
- \`deleteProject\` performs multiple sequential DB operations without transactions
- If the project deletion fails after todos were already moved/deleted, data is left inconsistent
- Now logs a clear error message indicating the partial state
- A full fix requires server-side transactions (Supabase Edge Function)

## Test plan
- [ ] Verify normal project deletion works
- [ ] Verify that a failure during deletion provides a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)