### PR TITLE
fix(security): reduce false positives in isEncrypted() heuristic

### DIFF
--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -93,8 +93,8 @@ export const CryptoUtils = {
 // Check if a string looks like encrypted data (base64 with IV prefix)
 export function isEncrypted(text) {
     if (!text || text.length < 24) return false
-    // Encrypted data is base64 with at least 12 bytes IV + some ciphertext
-    // Base64 of 24+ bytes = 32+ characters
+    if (/\s/.test(text)) return false
+    if (/^[a-f0-9]+$/i.test(text)) return false
     const base64Regex = /^[A-Za-z0-9+/]+=*$/
     return base64Regex.test(text) && text.length >= 32
 }


### PR DESCRIPTION
## Summary
- \`isEncrypted()\` used a broad base64 regex that could match plaintext hex strings and long alphanumeric text
- This caused the data migration to skip encrypting data that looked like base64 but was actually plaintext
- Added rejection of strings containing whitespace and pure hex strings
- Reduces false positives while maintaining detection of actual AES-GCM ciphertext

## Test plan
- [ ] Verify encrypted data is still correctly identified
- [ ] Verify long hex strings are not falsely identified as encrypted
- [ ] Verify normal plaintext with spaces is not identified as encrypted

🤖 Generated with [Claude Code](https://claude.com/claude-code)