### PR TITLE
fix(security): show user-visible error on refresh failure

### DIFF
--- a/app.js
+++ b/app.js
@@ -820,6 +820,7 @@ class TodoApp {
             ])
         } catch (error) {
             console.error('Error refreshing data:', error)
+            alert('Failed to refresh data. Please check your connection and try again.')
         } finally {
             this._suppressSignOut = false
             this.refreshBtn.disabled = false


### PR DESCRIPTION
## Summary
- \`refreshData()\` caught all errors but only logged to console
- The user continued working with stale data without knowing the refresh failed
- Now shows an alert on failure so the user knows to retry

## Test plan
- [ ] Verify refresh works normally
- [ ] Verify that a network error during refresh shows a visible error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)