### PR TITLE
feat: add urgent count badge to project sidebar

### DIFF
--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -139,6 +139,7 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.project-name/,
     /\.project-color/,
     /\.project-count/,
+    /\.project-urgent-count/,
     /\.project-delete/,
     /\.project-drag-handle/,
     /\.project-card/,

--- a/src/services/todos-filters.js
+++ b/src/services/todos-filters.js
@@ -146,3 +146,43 @@ export function getGtdCount(status) {
     }
     return todos.filter(t => t.gtd_status === status).length
 }
+
+function getTodayString() {
+    const now = new Date()
+    const y = now.getFullYear()
+    const m = String(now.getMonth() + 1).padStart(2, '0')
+    const d = String(now.getDate()).padStart(2, '0')
+    return `${y}-${m}-${d}`
+}
+
+export function getProjectUrgentCount(projectId, today) {
+    const todayStr = today || getTodayString()
+    const todos = store.get('todos')
+    const projects = store.get('projects')
+
+    const ids = [projectId]
+    const collect = (pid) => {
+        projects.filter(p => p.parent_id === pid).forEach(child => {
+            ids.push(child.id)
+            collect(child.id)
+        })
+    }
+    collect(projectId)
+
+    return todos.filter(t =>
+        ids.includes(t.project_id) &&
+        t.gtd_status !== 'done' &&
+        t.due_date &&
+        t.due_date <= todayStr
+    ).length
+}
+
+export function getAllUrgentCount(today) {
+    const todayStr = today || getTodayString()
+    const todos = store.get('todos')
+    return todos.filter(t =>
+        t.gtd_status !== 'done' &&
+        t.due_date &&
+        t.due_date <= todayStr
+    ).length
+}

--- a/src/ui/ProjectList.js
+++ b/src/ui/ProjectList.js
@@ -1,7 +1,7 @@
 import { store } from '../core/store.js'
 import { escapeHtml, validateColor } from '../utils/security.js'
 import { getFilteredProjects, selectProject, deleteProject, addProject, updateProject, reorderProjects, getDescendantIds } from '../services/projects.js'
-import { getProjectTodoCount, updateTodoProject } from '../services/todos.js'
+import { getProjectTodoCount, getProjectUrgentCount, getAllUrgentCount, updateTodoProject } from '../services/todos.js'
 import { getIcon } from '../utils/icons.js'
 
 /**
@@ -147,8 +147,13 @@ export function renderProjects(container) {
     allItem.className = `project-item ${state.selectedProjectId === null ? 'active' : ''}`
     const totalCount = state.todos.filter(t => t.gtd_status !== 'done').length
     const totalCountDisplay = totalCount > 0 ? totalCount : ''
+    const allUrgent = getAllUrgentCount()
+    const allUrgentHtml = allUrgent > 0
+        ? `<span class="project-urgent-count">${allUrgent}</span>`
+        : ''
     allItem.innerHTML = `
         <span class="project-name">All Projects</span>
+        ${allUrgentHtml}
         <span class="project-count">${totalCountDisplay}</span>
     `
     allItem.addEventListener('click', () => selectProject(null))
@@ -211,6 +216,10 @@ function renderProjectTree(container, projects, parentId, depth) {
 
         const count = getProjectTodoCount(project.id)
         const countDisplay = count > 0 ? count : ''
+        const urgentCount = getProjectUrgentCount(project.id)
+        const urgentHtml = urgentCount > 0
+            ? `<span class="project-urgent-count">${urgentCount}</span>`
+            : ''
 
         const hasChildren = projects.some(p => p.parent_id === project.id)
         const isCollapsed = collapsedProjects.has(project.id)
@@ -236,6 +245,7 @@ function renderProjectTree(container, projects, parentId, depth) {
                 <span class="project-color" style="background-color: ${colorStyle}"></span>
                 ${safeName}
             </span>
+            ${urgentHtml}
             <span class="project-count">${countDisplay}</span>
             <button class="project-delete" data-id="${project.id}">${deleteIconHtml}</button>
         `

--- a/styles.css
+++ b/styles.css
@@ -694,6 +694,20 @@ body.sidebar-resizing * {
     margin-right: 4px;
 }
 
+.project-urgent-count {
+    font-size: 11px;
+    font-weight: 600;
+    color: #fff;
+    background-color: #ff3b30;
+    min-width: 18px;
+    height: 18px;
+    line-height: 18px;
+    border-radius: 9px;
+    text-align: center;
+    padding: 0 4px;
+    box-sizing: border-box;
+}
+
 .project-item.active .project-count {
     color: rgba(255, 255, 255, 0.8);
 }
@@ -5523,6 +5537,12 @@ body.sidebar-resizing * {
 [data-theme="dark"] .project-item.active .project-count,
 [data-theme="clear"] .project-item.active .project-count {
     color: var(--ios-blue);
+}
+
+[data-theme="glass"] .project-urgent-count,
+[data-theme="dark"] .project-urgent-count,
+[data-theme="clear"] .project-urgent-count {
+    background-color: #ff453a;
 }
 
 [data-theme="glass"] .project-expand,

--- a/tests/unit/todos-filters.test.js
+++ b/tests/unit/todos-filters.test.js
@@ -21,7 +21,7 @@ vi.mock('../../src/core/store.js', () => {
     }
 })
 
-import { getFilteredTodos, getProjectTodoCount, getGtdCount } from '../../src/services/todos-filters.js'
+import { getFilteredTodos, getProjectTodoCount, getGtdCount, getProjectUrgentCount, getAllUrgentCount } from '../../src/services/todos-filters.js'
 import { store } from '../../src/core/store.js'
 
 /**
@@ -702,5 +702,150 @@ describe('getGtdCount', () => {
         const onlyInbox = [{ id: 1, gtd_status: 'inbox', due_date: null }]
         resetState({ todos: onlyInbox })
         expect(getGtdCount('next_action')).toBe(0)
+    })
+})
+
+// ─── getProjectUrgentCount ──────────────────────────────────────────────────
+
+describe('getProjectUrgentCount', () => {
+    beforeEach(() => {
+        resetState()
+    })
+
+    const today = '2026-04-30'
+
+    it('returns 0 when project has no todos', () => {
+        resetState({ todos: [], projects: [] })
+        expect(getProjectUrgentCount('proj-1', today)).toBe(0)
+    })
+
+    it('counts todos with due_date on today', () => {
+        resetState({
+            todos: [
+                { id: 1, project_id: 'proj-1', gtd_status: 'inbox', due_date: '2026-04-30' },
+                { id: 2, project_id: 'proj-1', gtd_status: 'inbox', due_date: '2026-05-01' }
+            ],
+            projects: []
+        })
+        expect(getProjectUrgentCount('proj-1', today)).toBe(1)
+    })
+
+    it('counts todos with due_date before today (overdue)', () => {
+        resetState({
+            todos: [
+                { id: 1, project_id: 'proj-1', gtd_status: 'inbox', due_date: '2026-04-28' },
+                { id: 2, project_id: 'proj-1', gtd_status: 'inbox', due_date: '2026-04-29' }
+            ],
+            projects: []
+        })
+        expect(getProjectUrgentCount('proj-1', today)).toBe(2)
+    })
+
+    it('excludes done todos', () => {
+        resetState({
+            todos: [
+                { id: 1, project_id: 'proj-1', gtd_status: 'done', due_date: '2026-04-28' },
+                { id: 2, project_id: 'proj-1', gtd_status: 'inbox', due_date: '2026-04-28' }
+            ],
+            projects: []
+        })
+        expect(getProjectUrgentCount('proj-1', today)).toBe(1)
+    })
+
+    it('excludes todos without a due_date', () => {
+        resetState({
+            todos: [
+                { id: 1, project_id: 'proj-1', gtd_status: 'inbox', due_date: null },
+                { id: 2, project_id: 'proj-1', gtd_status: 'inbox', due_date: '2026-04-28' }
+            ],
+            projects: []
+        })
+        expect(getProjectUrgentCount('proj-1', today)).toBe(1)
+    })
+
+    it('includes todos from descendant projects', () => {
+        resetState({
+            todos: [
+                { id: 1, project_id: 'proj-parent', gtd_status: 'inbox', due_date: '2026-04-28' },
+                { id: 2, project_id: 'proj-child', gtd_status: 'inbox', due_date: '2026-04-29' },
+                { id: 3, project_id: 'proj-grandchild', gtd_status: 'inbox', due_date: '2026-04-30' }
+            ],
+            projects: [
+                { id: 'proj-parent', parent_id: null },
+                { id: 'proj-child', parent_id: 'proj-parent' },
+                { id: 'proj-grandchild', parent_id: 'proj-child' }
+            ]
+        })
+        expect(getProjectUrgentCount('proj-parent', today)).toBe(3)
+    })
+
+    it('does not count future-dated todos', () => {
+        resetState({
+            todos: [
+                { id: 1, project_id: 'proj-1', gtd_status: 'inbox', due_date: '2026-05-01' },
+                { id: 2, project_id: 'proj-1', gtd_status: 'inbox', due_date: '2027-01-01' }
+            ],
+            projects: []
+        })
+        expect(getProjectUrgentCount('proj-1', today)).toBe(0)
+    })
+
+    it('does not count todos from other projects', () => {
+        resetState({
+            todos: [
+                { id: 1, project_id: 'proj-1', gtd_status: 'inbox', due_date: '2026-04-28' },
+                { id: 2, project_id: 'proj-2', gtd_status: 'inbox', due_date: '2026-04-28' }
+            ],
+            projects: []
+        })
+        expect(getProjectUrgentCount('proj-1', today)).toBe(1)
+    })
+})
+
+// ─── getAllUrgentCount ───────────────────────────────────────────────────────
+
+describe('getAllUrgentCount', () => {
+    beforeEach(() => {
+        resetState()
+    })
+
+    const today = '2026-04-30'
+
+    it('returns 0 when there are no todos', () => {
+        resetState({ todos: [] })
+        expect(getAllUrgentCount(today)).toBe(0)
+    })
+
+    it('counts all non-done todos with due_date on or before today', () => {
+        resetState({
+            todos: [
+                { id: 1, gtd_status: 'inbox', due_date: '2026-04-28' },
+                { id: 2, gtd_status: 'next_action', due_date: '2026-04-30' },
+                { id: 3, gtd_status: 'inbox', due_date: '2026-05-01' },
+                { id: 4, gtd_status: 'done', due_date: '2026-04-28' },
+                { id: 5, gtd_status: 'inbox', due_date: null }
+            ]
+        })
+        expect(getAllUrgentCount(today)).toBe(2)
+    })
+
+    it('returns 0 when all todos are in the future', () => {
+        resetState({
+            todos: [
+                { id: 1, gtd_status: 'inbox', due_date: '2026-05-01' },
+                { id: 2, gtd_status: 'inbox', due_date: '2027-01-01' }
+            ]
+        })
+        expect(getAllUrgentCount(today)).toBe(0)
+    })
+
+    it('returns 0 when all urgent todos are done', () => {
+        resetState({
+            todos: [
+                { id: 1, gtd_status: 'done', due_date: '2026-04-28' },
+                { id: 2, gtd_status: 'done', due_date: '2026-04-30' }
+            ]
+        })
+        expect(getAllUrgentCount(today)).toBe(0)
     })
 })


### PR DESCRIPTION
## Summary

- Adds a red/pink circular badge to each project in the sidebar showing the count of todos due today or overdue
- Badge appears to the left of the existing total count, only when count > 0
- The "All Projects" row also shows the total urgent count across all projects
- Includes themed variants for glass, dark, and clear themes

## Changes

| File | Change |
|------|--------|
| `src/services/todos-filters.js` | New `getProjectUrgentCount()` and `getAllUrgentCount()` functions |
| `src/ui/ProjectList.js` | Render urgent badge in both "All Projects" and individual project rows |
| `styles.css` | `.project-urgent-count` base + themed styles |
| `tests/unit/todos-filters.test.js` | 12 new tests for the urgent count functions |
| `scripts/check-css-selectors.js` | Added dynamic selector to allowlist |

## Test plan

- [x] All 1160 unit tests pass
- [x] CSS selector validation passes
- [ ] Visual check: projects with today/overdue items show red badge
- [ ] Visual check: projects without urgent items show no badge
- [ ] Visual check: badge renders correctly across all themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)