### PR TITLE
fix(ui): align checkboxes to top of todo items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1300,7 +1300,7 @@ body.sidebar-resizing * {
     border-radius: 8px;
     display: flex;
     flex-wrap: nowrap; /* Prevent Safari iOS from incorrectly wrapping flex items */
-    align-items: center;
+    align-items: flex-start;
     gap: 12px;
     transition: background 0.3s, transform 0.3s, opacity 0.3s, box-shadow 0.3s;
     border-left: 4px solid transparent;


### PR DESCRIPTION
## Summary
- Fixed checkbox vertical alignment in todo items with multi-line content (e.g., todos with subtitle/URL comments)
- Changed `.todo-item` from `align-items: center` to `align-items: flex-start` so checkboxes stay pinned to the top, consistent with single-line todos

## Test plan
- [ ] Verify single-line todos still look correct (checkbox aligned with text)
- [ ] Verify multi-line todos (with comments/URLs) have checkbox aligned with the first line
- [ ] Test across themes (Glass, Dark, Clear)
- [ ] Test in compact density mode (uses grid layout, unaffected by this change)
- [ ] Test on mobile (uses grid layout, unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)