### PR TITLE
fix: marquee selection bulk delete not persisting to database

### DIFF
--- a/src/ui/MarqueeSelect.js
+++ b/src/ui/MarqueeSelect.js
@@ -203,7 +203,7 @@ export class MarqueeSelect {
             )
 
             if (intersects) {
-                const todoId = item.dataset.todoId
+                const todoId = Number(item.dataset.todoId)
                 if (todoId) {
                     newIntersectedIds.add(todoId)
                     item.classList.add('marquee-hover')


### PR DESCRIPTION
## Summary
- Marquee drag-to-select stored todo IDs as strings (from DOM `dataset`), but Supabase returns BIGINT IDs as numbers
- This type mismatch caused `bulkDeleteTodos` to silently skip both the local store removal and the DB delete
- Fix: wrap `dataset.todoId` with `Number()` in `MarqueeSelect._computeIntersections()`

## Test plan
- [ ] Select todos via marquee drag, bulk delete, verify they stay deleted after page refresh
- [ ] Verify Ctrl+click and Shift+click selection still work correctly with bulk operations
- [ ] Unit tests pass (1172/1172)

🤖 Generated with [Claude Code](https://claude.com/claude-code)