### PR TITLE
Fix: delete todo not persisting to database

### DIFF
--- a/DATABASE_MIGRATION.md
+++ b/DATABASE_MIGRATION.md
@@ -1,0 +1,36 @@
+# Database Migrations
+
+Run these SQL statements in the Supabase SQL Editor (Dashboard → SQL Editor).
+
+---
+
+## Fix: Add missing DELETE RLS policies
+
+**Problem:** The `todos` (and `categories`) tables had SELECT/INSERT/UPDATE policies but no DELETE policy. Supabase RLS denies DELETE by default when no policy exists, returning no error but affecting 0 rows — causing silent data loss on the client side.
+
+**Run in Supabase SQL Editor:**
+
+```sql
+-- Allow users to delete their own todos
+CREATE POLICY "Users can delete their own todos"
+ON todos
+FOR DELETE
+USING (auth.uid() = user_id);
+
+-- Allow users to delete their own categories
+CREATE POLICY "Users can delete their own categories"
+ON categories
+FOR DELETE
+USING (auth.uid() = user_id);
+```
+
+**Verify existing policies (optional):**
+
+```sql
+SELECT schemaname, tablename, policyname, cmd, qual
+FROM pg_policies
+WHERE tablename IN ('todos', 'categories')
+ORDER BY tablename, cmd;
+```
+
+Expected output should include a row for `DELETE` on both tables.

--- a/index.html
+++ b/index.html
@@ -1286,14 +1286,21 @@
             }
 
             async deleteTodo(id) {
-                const { error } = await supabase
+                const { data, error } = await supabase
                     .from('todos')
                     .delete()
                     .eq('id', id)
+                    .select('id')
 
                 if (error) {
                     console.error('Error deleting todo:', error)
                     alert('Failed to delete todo')
+                    return
+                }
+
+                if (!data || data.length === 0) {
+                    console.error('Delete todo: no rows affected for id', id)
+                    alert('Failed to delete todo. The database did not remove the record — please refresh and try again.')
                     return
                 }
 


### PR DESCRIPTION
## Root cause

Supabase JS v2 silently returns `{ error: null }` with **0 rows affected** when a `DELETE` is blocked by RLS (or no DELETE policy exists on the table). The `deleteTodo()` method only checked `if (error)`, so it always assumed success — optimistically removing the item from local state while the database row was never actually deleted. On a full page reload, `loadTodos()` fetched from Supabase and the item reappeared.

The underlying database issue: the `todos` (and `categories`) tables likely have SELECT/INSERT policies but **no DELETE RLS policy**. Supabase denies DELETE by default when no policy exists.

## Code fix

Chained `.select('id')` on the Supabase delete call so the response includes the actually-deleted rows. If the result is empty (0 rows), the user now sees an error message instead of a silent UI lie.

## Database fix required (before merging)

Run this SQL in the **Supabase SQL Editor** to add the missing DELETE RLS policies:

```sql
CREATE POLICY "Users can delete their own todos"
ON todos FOR DELETE USING (auth.uid() = user_id);

CREATE POLICY "Users can delete their own categories"
ON categories FOR DELETE USING (auth.uid() = user_id);
```

The full SQL (plus a verification query) is also documented in `DATABASE_MIGRATION.md`.

## Test plan

- [ ] Run the SQL above in Supabase SQL Editor
- [ ] Log in and delete a todo — it should disappear and stay gone after page reload
- [ ] Verify in Supabase Table Editor that the row is removed
- [ ] (Optional) Temporarily remove the DELETE policy and confirm the new error message appears instead of a silent UI lie

🤖 Generated with [Claude Code](https://claude.com/claude-code)