### PR TITLE
Fix: recurring todo reappears after deletion

### DIFF
--- a/scripts/check-css-selectors.js
+++ b/scripts/check-css-selectors.js
@@ -198,6 +198,15 @@ const DYNAMIC_ELEMENT_SELECTORS = [
     /\.areas-item-shortcut/,
     // Delete project dialog (rendered by JavaScript)
     /\.delete-project-dialog/,
+    // Recurring-delete confirmation dialog (rendered by JavaScript)
+    /\.recurring-delete-overlay/,
+    /\.recurring-delete-dialog/,
+    /\.recurring-delete-title/,
+    /\.recurring-delete-body/,
+    /\.recurring-delete-actions/,
+    /\.recurring-delete-btn-occurrence/,
+    /\.recurring-delete-btn-series/,
+    /\.recurring-delete-btn-cancel/,
     // Toast notifications (rendered by JavaScript)
     /\.toast/,
     /\.toast-visible/,

--- a/src/ui/TodoList.js
+++ b/src/ui/TodoList.js
@@ -2,6 +2,7 @@ import { store } from '../core/store.js'
 import { escapeHtml, validateColor } from '../utils/security.js'
 import { formatDateBadge, getDateGroup, getDateGroupLabel } from '../utils/dates.js'
 import { getFilteredTodos, toggleTodo, deleteTodo, updateTodoProject, updateTodoGtdStatus, getProjectTodoCount, toggleTodoSelection, selectTodoRange } from '../services/todos.js'
+import { deleteRecurringSeries, generateNextRecurrence } from '../services/todos-recurrence.js'
 import { getProjectPath, selectProject } from '../services/projects.js'
 import { getCategoryById } from '../services/categories.js'
 import { getPriorityById } from '../services/priorities.js'
@@ -327,8 +328,64 @@ export function renderTodos(container, options = {}) {
         })
 
         const deleteBtn = li.querySelector('.delete-btn')
-        deleteBtn.addEventListener('click', () => deleteTodo(todo.id))
+        deleteBtn.addEventListener('click', () => {
+            if (todo.template_id) {
+                showRecurringDeleteDialog(todo)
+            } else {
+                deleteTodo(todo.id)
+            }
+        })
 
         container.appendChild(li)
     })
+}
+
+/**
+ * Show a dialog when deleting a recurring todo instance.
+ * Asks the user whether to delete just this occurrence or the entire series.
+ * "This occurrence" deletes the instance and generates the next one so the
+ * series continues. "Entire series" removes the template and all instances.
+ */
+function showRecurringDeleteDialog(todo) {
+    const overlay = document.createElement('div')
+    overlay.className = 'recurring-delete-overlay'
+    overlay.innerHTML = `
+        <div class="recurring-delete-dialog" role="dialog" aria-modal="true" aria-label="Delete recurring task">
+            <h3 class="recurring-delete-title">Recurring task</h3>
+            <p class="recurring-delete-body">What would you like to delete?</p>
+            <div class="recurring-delete-actions">
+                <button class="recurring-delete-btn-occurrence">This occurrence only</button>
+                <button class="recurring-delete-btn-series">Entire series</button>
+                <button class="recurring-delete-btn-cancel">Cancel</button>
+            </div>
+        </div>
+    `
+
+    const close = () => overlay.remove()
+
+    overlay.querySelector('.recurring-delete-btn-occurrence').addEventListener('click', async () => {
+        close()
+        await deleteTodo(todo.id)
+        // Generate the next occurrence so the series continues and catch-up
+        // logic on next load doesn't regenerate from old completed instances.
+        if (todo.template_id) {
+            const today = new Date().toISOString().split('T')[0]
+            await generateNextRecurrence(todo.template_id, todo.due_date || today)
+        }
+    })
+
+    overlay.querySelector('.recurring-delete-btn-series').addEventListener('click', async () => {
+        close()
+        await deleteRecurringSeries(todo.template_id)
+    })
+
+    overlay.querySelector('.recurring-delete-btn-cancel').addEventListener('click', close)
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) close() })
+
+    // Close on Escape
+    const onKey = (e) => { if (e.key === 'Escape') { close(); document.removeEventListener('keydown', onKey) } }
+    document.addEventListener('keydown', onKey)
+
+    document.body.appendChild(overlay)
+    overlay.querySelector('.recurring-delete-btn-occurrence').focus()
 }

--- a/styles.css
+++ b/styles.css
@@ -6900,3 +6900,88 @@ body.marquee-dragging * {
         max-width: none;
     }
 }
+
+/* ── Recurring-delete confirmation dialog ──────────────────────────────────── */
+.recurring-delete-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 10001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.recurring-delete-dialog {
+    background: white;
+    border-radius: 12px;
+    padding: 28px 32px;
+    max-width: 380px;
+    width: 90%;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+}
+
+.recurring-delete-title {
+    margin: 0 0 8px;
+    font-size: 17px;
+    font-weight: 600;
+}
+
+.recurring-delete-body {
+    margin: 0 0 20px;
+    color: #555;
+    font-size: 14px;
+}
+
+.recurring-delete-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.recurring-delete-btn-occurrence,
+.recurring-delete-btn-series,
+.recurring-delete-btn-cancel {
+    padding: 10px 16px;
+    border-radius: 7px;
+    border: none;
+    font-size: 14px;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.15s;
+}
+
+.recurring-delete-btn-occurrence {
+    background: #f0f0f0;
+    color: #222;
+}
+.recurring-delete-btn-occurrence:hover { background: #e0e0e0; }
+
+.recurring-delete-btn-series {
+    background: #e74c3c;
+    color: white;
+}
+.recurring-delete-btn-series:hover { background: #c0392b; }
+
+.recurring-delete-btn-cancel {
+    background: transparent;
+    color: #888;
+}
+.recurring-delete-btn-cancel:hover { background: #f5f5f5; }
+
+/* Dark theme */
+[data-theme="dark"] .recurring-delete-dialog,
+[data-theme="glass"] .recurring-delete-dialog {
+    background: #2a2a2a;
+    color: #eee;
+}
+[data-theme="dark"] .recurring-delete-body,
+[data-theme="glass"] .recurring-delete-body { color: #aaa; }
+[data-theme="dark"] .recurring-delete-btn-occurrence,
+[data-theme="glass"] .recurring-delete-btn-occurrence { background: #3a3a3a; color: #eee; }
+[data-theme="dark"] .recurring-delete-btn-occurrence:hover,
+[data-theme="glass"] .recurring-delete-btn-occurrence:hover { background: #444; }
+[data-theme="dark"] .recurring-delete-btn-cancel,
+[data-theme="glass"] .recurring-delete-btn-cancel { color: #777; }
+[data-theme="dark"] .recurring-delete-btn-cancel:hover,
+[data-theme="glass"] .recurring-delete-btn-cancel:hover { background: #333; }


### PR DESCRIPTION
## Root cause

Deleting an instance of a recurring todo (`[REGULAR] Slack Later`) only removed that instance from the database. The **template** (which drives the series) was left intact. On the next page load, `checkPendingRecurrences()` ran, found an older completed past-due instance, and generated a new catch-up occurrence — making the task appear to silently "come back".

The delete was working correctly all along. The bug was the catch-up generator recreating it.

## Fix

When clicking Delete on a recurring todo (any todo with a `template_id`), a dialog now appears with two options:

| Choice | What happens |
|---|---|
| **This occurrence only** | Deletes the instance, then generates the **next future occurrence** so the series continues. The `checkPendingRecurrences` catch-up logic no longer regenerates from the old completed instance because there is now a fresh non-completed future instance. |
| **Entire series** | Calls `deleteRecurringSeries()` — removes the template and all instances. |

Non-recurring todos still delete immediately without any dialog.

## Files changed

- `src/ui/TodoList.js` — import `deleteRecurringSeries` + `generateNextRecurrence`; wire delete button to dialog for recurring instances; add `showRecurringDeleteDialog()` helper
- `styles.css` — dialog overlay and button styles (dark/glass theme variants included)
- `scripts/check-css-selectors.js` — register new dynamically-created CSS classes in the ignore list

## Test plan

- [ ] Delete a non-recurring todo → deletes immediately, no dialog
- [ ] Delete a recurring todo → dialog appears with "This occurrence only", "Entire series", "Cancel"
- [ ] "This occurrence only" → item disappears, a new occurrence with the next due date appears; after full page refresh the old item does NOT come back
- [ ] "Entire series" → all occurrences + template gone; item does not reappear after refresh
- [ ] Cancel / Escape / click overlay → dialog closes, todo unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)