### PR TITLE
fix(tests): handle recurring delete dialog in E2E deleteTodo helpers

### DIFF
--- a/tests/e2e/helpers/todos.js
+++ b/tests/e2e/helpers/todos.js
@@ -64,6 +64,11 @@ export async function deleteTodo(page, text) {
     const item = todoItem(page, text)
     if (await item.count() > 0) {
         await item.locator('.delete-btn').click()
+        // Dismiss recurring-delete dialog if it appears (click "Entire series")
+        try {
+            await page.locator('.recurring-delete-overlay').waitFor({ state: 'visible', timeout: 1000 })
+            await page.click('.recurring-delete-btn-series')
+        } catch { /* non-recurring todo — no dialog */ }
         await expect(item).not.toBeAttached({ timeout: 5000 })
     }
 }

--- a/tests/e2e/recurring-advanced.spec.js
+++ b/tests/e2e/recurring-advanced.spec.js
@@ -24,6 +24,11 @@ async function deleteTodo(page, text) {
     const item = todoItem(page, text)
     if (await item.count() > 0) {
         await item.locator('.delete-btn').click()
+        // Dismiss recurring-delete dialog if it appears (click "Entire series")
+        try {
+            await page.locator('.recurring-delete-overlay').waitFor({ state: 'visible', timeout: 1000 })
+            await page.click('.recurring-delete-btn-series')
+        } catch { /* non-recurring todo — no dialog */ }
         await expect(item).not.toBeAttached({ timeout: 5000 })
     }
 }

--- a/tests/e2e/recurring.spec.js
+++ b/tests/e2e/recurring.spec.js
@@ -24,6 +24,11 @@ async function deleteTodo(page, text) {
     const item = todoItem(page, text)
     if (await item.count() > 0) {
         await item.locator('.delete-btn').click()
+        // Dismiss recurring-delete dialog if it appears (click "Entire series")
+        try {
+            await page.locator('.recurring-delete-overlay').waitFor({ state: 'visible', timeout: 1000 })
+            await page.click('.recurring-delete-btn-series')
+        } catch { /* non-recurring todo — no dialog */ }
         await expect(item).not.toBeAttached({ timeout: 5000 })
     }
 }


### PR DESCRIPTION
## Summary

- The recurring-todo delete fix (#559) introduced a confirmation dialog when deleting a recurring todo instance (asking "This occurrence only" vs "Entire series")
- The three `deleteTodo` E2E helpers (`recurring.spec.js`, `recurring-advanced.spec.js`, `helpers/todos.js`) were not aware of this dialog — they clicked `.delete-btn` and immediately asserted the item was gone, causing 17 test failures in the `test (recurrence)` CI job
- Each helper now waits up to 1 s for `.recurring-delete-overlay` to appear; if it does, clicks "Entire series" to complete the deletion; non-recurring todos skip that branch via the `catch`

## Test plan

- [ ] `test (recurrence)` CI job passes (was 17 failures, 29 passing → should be 0 failures)
- [ ] No regressions in other E2E shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)